### PR TITLE
Support for FlatLink styled as a Button

### DIFF
--- a/explorer/src/Stories/FlatLink.elm
+++ b/explorer/src/Stories/FlatLink.elm
@@ -53,4 +53,19 @@ stories =
                     ]
           , {}
           )
+        , ( "With buttonStyle"
+          , \_ ->
+                Html.div [ css [ children [ everything [ marginBottom (rem 1) ] ] ] ]
+                    [ FlatLink.default
+                        |> FlatLink.withButtonStyle
+                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ text "Click me" ]
+                    , FlatLink.default
+                        |> FlatLink.withButtonStyle
+                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ text "Click me", Icons.rightIcon Icons.info ]
+                    , FlatLink.default
+                        |> FlatLink.withButtonStyle
+                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ Icons.leftIcon Icons.info, text "Click me" ]
+                    ]
+          , {}
+          )
         ]

--- a/explorer/src/Stories/FlatLink.elm
+++ b/explorer/src/Stories/FlatLink.elm
@@ -4,6 +4,7 @@ import Css exposing (marginBottom, rem)
 import Css.Global exposing (children, everything)
 import Html.Styled as Html exposing (text)
 import Html.Styled.Attributes exposing (css, href)
+import Nordea.Components.Button as ButtonVariant
 import Nordea.Components.FlatLink as FlatLink
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
@@ -53,18 +54,18 @@ stories =
                     ]
           , {}
           )
-        , ( "With buttonStyle"
+        , ( "withButtonStyle"
           , \_ ->
                 Html.div [ css [ children [ everything [ marginBottom (rem 1) ] ] ] ]
                     [ FlatLink.default
-                        |> FlatLink.withButtonStyle
-                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ text "Click me" ]
+                        |> FlatLink.withButtonStyle ButtonVariant.Primary
+                        |> FlatLink.view [ href "/#Default/FlatLink/withButtonStyle" ] [ text "Click me" ]
                     , FlatLink.default
-                        |> FlatLink.withButtonStyle
-                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ text "Click me", Icons.rightIcon Icons.info ]
+                        |> FlatLink.withButtonStyle ButtonVariant.Primary
+                        |> FlatLink.view [ href "/#Default/FlatLink/withButtonStyle" ] [ text "Click me", Icons.rightIcon Icons.info ]
                     , FlatLink.default
-                        |> FlatLink.withButtonStyle
-                        |> FlatLink.view [ href "/#Default/FlatLink/Default" ] [ Icons.leftIcon Icons.info, text "Click me" ]
+                        |> FlatLink.withButtonStyle ButtonVariant.Primary
+                        |> FlatLink.view [ href "/#Default/FlatLink/withButtonStyle" ] [ Icons.leftIcon Icons.info, text "Click me" ]
                     ]
           , {}
           )

--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -1,5 +1,7 @@
 module Nordea.Components.Button exposing
     ( Button
+    , Variant(..)
+    , buttonStyleForExport
     , primary
     , secondary
     , tertiary
@@ -179,3 +181,8 @@ variantStyle variant =
                     , boxShadow5 zero zero zero (rem 0.25) Colors.blueHaas
                     ]
                 ]
+
+
+buttonStyleForExport : Variant -> Style
+buttonStyleForExport variant =
+    batch [ baseStyle, variantStyle variant ]

--- a/src/Nordea/Components/FlatLink.elm
+++ b/src/Nordea/Components/FlatLink.elm
@@ -23,6 +23,7 @@ import Css
         , fontSize
         , hover
         , lineHeight
+        , maxWidth
         , none
         , num
         , opacity
@@ -153,7 +154,7 @@ variantStyle variant =
 
 buttonStyle : Button.Variant -> List Style
 buttonStyle buttonVariant =
-    [ Css.maxWidth fitContent
+    [ maxWidth fitContent
     , textDecoration none
     , Button.buttonStyleForExport buttonVariant
     ]

--- a/src/Nordea/Components/FlatLink.elm
+++ b/src/Nordea/Components/FlatLink.elm
@@ -3,6 +3,7 @@ module Nordea.Components.FlatLink exposing
     , default
     , mini
     , view
+    , withButtonStyle
     , withDisabled
     , withStyles
     )
@@ -11,24 +12,37 @@ import Css
     exposing
         ( Style
         , alignItems
+        , backgroundColor
+        , border3
         , borderBox
+        , borderRadius
+        , boxShadow5
         , boxSizing
         , center
         , color
         , cursor
+        , disabled
         , displayFlex
+        , fitContent
         , focus
+        , fontFamilies
         , fontSize
+        , fontWeight
         , hover
+        , int
         , lineHeight
         , none
         , num
         , opacity
+        , outline
+        , padding2
         , pointer
         , pointerEvents
         , rem
+        , solid
         , textDecoration
         , underline
+        , zero
         )
 import Html.Styled as Html exposing (Attribute, Html)
 import Nordea.Resources.Colors as Colors
@@ -74,6 +88,11 @@ withStyles styles (FlatLink config) =
 withDisabled : FlatLink -> FlatLink
 withDisabled (FlatLink config) =
     FlatLink { config | isDisabled = Just True }
+
+
+withButtonStyle : FlatLink -> FlatLink
+withButtonStyle (FlatLink config) =
+    FlatLink { config | styles = buttonStyle }
 
 
 
@@ -141,3 +160,36 @@ variantStyle variant =
                 [ fontSize (rem 0.875)
                 , lineHeight (rem 1.125)
                 ]
+
+
+buttonStyle : List Style
+buttonStyle =
+    [ fontFamilies [ "inherit" ]
+    , Css.maxWidth fitContent
+    , textDecoration none
+    , displayFlex
+    , alignItems center
+    , fontSize (rem 1)
+    , fontWeight (int 500)
+    , padding2 (rem 0.5) (rem 1)
+    , borderRadius (rem 2)
+    , cursor pointer
+    , boxSizing borderBox
+    , backgroundColor Colors.blueDeep
+    , color Colors.white
+    , border3 (rem 0.125) solid Colors.transparent
+    , hover
+        [ backgroundColor Colors.blueCloud
+        , color Colors.blueDeep
+        ]
+    , focus
+        [ outline none
+        , backgroundColor Colors.blueNordea
+        , color Colors.blueHaas
+        , boxShadow5 zero zero zero (rem 0.25) Colors.blueHaas
+        ]
+    , disabled
+        [ opacity (num 0.25)
+        , pointerEvents none
+        ]
+    ]

--- a/src/Nordea/Components/FlatLink.elm
+++ b/src/Nordea/Components/FlatLink.elm
@@ -12,39 +12,28 @@ import Css
     exposing
         ( Style
         , alignItems
-        , backgroundColor
-        , border3
         , borderBox
-        , borderRadius
-        , boxShadow5
         , boxSizing
         , center
         , color
         , cursor
-        , disabled
         , displayFlex
         , fitContent
         , focus
-        , fontFamilies
         , fontSize
-        , fontWeight
         , hover
-        , int
         , lineHeight
         , none
         , num
         , opacity
-        , outline
-        , padding2
         , pointer
         , pointerEvents
         , rem
-        , solid
         , textDecoration
         , underline
-        , zero
         )
 import Html.Styled as Html exposing (Attribute, Html)
+import Nordea.Components.Button as Button
 import Nordea.Resources.Colors as Colors
 
 
@@ -90,9 +79,9 @@ withDisabled (FlatLink config) =
     FlatLink { config | isDisabled = Just True }
 
 
-withButtonStyle : FlatLink -> FlatLink
-withButtonStyle (FlatLink config) =
-    FlatLink { config | styles = buttonStyle }
+withButtonStyle : Button.Variant -> FlatLink -> FlatLink
+withButtonStyle buttonVariant (FlatLink config) =
+    FlatLink { config | styles = buttonStyle buttonVariant }
 
 
 
@@ -162,34 +151,9 @@ variantStyle variant =
                 ]
 
 
-buttonStyle : List Style
-buttonStyle =
-    [ fontFamilies [ "inherit" ]
-    , Css.maxWidth fitContent
+buttonStyle : Button.Variant -> List Style
+buttonStyle buttonVariant =
+    [ Css.maxWidth fitContent
     , textDecoration none
-    , displayFlex
-    , alignItems center
-    , fontSize (rem 1)
-    , fontWeight (int 500)
-    , padding2 (rem 0.5) (rem 1)
-    , borderRadius (rem 2)
-    , cursor pointer
-    , boxSizing borderBox
-    , backgroundColor Colors.blueDeep
-    , color Colors.white
-    , border3 (rem 0.125) solid Colors.transparent
-    , hover
-        [ backgroundColor Colors.blueCloud
-        , color Colors.blueDeep
-        ]
-    , focus
-        [ outline none
-        , backgroundColor Colors.blueNordea
-        , color Colors.blueHaas
-        , boxShadow5 zero zero zero (rem 0.25) Colors.blueHaas
-        ]
-    , disabled
-        [ opacity (num 0.25)
-        , pointerEvents none
-        ]
+    , Button.buttonStyleForExport buttonVariant
     ]


### PR DESCRIPTION
By using the `withButtonStyles` function for FlatLink, we can now have a-tags styled as buttons

![image](https://user-images.githubusercontent.com/14363025/122213669-7b65dc00-cea9-11eb-9c71-5e8d0622858a.png)
