### PR TITLE
Add error border line on text input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 
 # Desktop Services Store on macOS
 .DS_Store
+
+.idea/

--- a/explorer/src/Stories/TextInput.elm
+++ b/explorer/src/Stories/TextInput.elm
@@ -29,11 +29,11 @@ stories =
                     |> TextInput.view []
           , {}
           )
-          ,( "Error"
-         , \_ ->
-               TextInput.init "Text"
-                   |> TextInput.withError True
-                   |> TextInput.view []
-         , {}
-         )
+        , ( "Error"
+          , \_ ->
+                TextInput.init "Text"
+                    |> TextInput.withError True
+                    |> TextInput.view []
+          , {}
+          )
         ]

--- a/explorer/src/Stories/TextInput.elm
+++ b/explorer/src/Stories/TextInput.elm
@@ -29,4 +29,11 @@ stories =
                     |> TextInput.view []
           , {}
           )
+          ,( "Error"
+         , \_ ->
+               TextInput.init "Text"
+                   |> TextInput.withError True
+                   |> TextInput.view []
+         , {}
+         )
         ]

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -23,7 +23,7 @@ type alias Config msg =
     { value : String
     , onInput : Maybe (String -> msg)
     , placeholder : Maybe String
-    , error : Maybe Bool
+    , showError : Bool
     }
 
 
@@ -37,7 +37,7 @@ init value =
         { value = value
         , onInput = Nothing
         , placeholder = Nothing
-        , error = Nothing
+        , showError = False
         }
 
 
@@ -52,7 +52,7 @@ withPlaceholder placeholder (TextInput config) =
 
 withError : Bool -> TextInput msg -> TextInput msg
 withError condition (TextInput config) =
-    TextInput { config | error = Just condition }
+    TextInput { config | showError = condition }
 
 
 
@@ -79,17 +79,9 @@ getAttributes config =
 getStyles : Config msg -> List Style
 getStyles config =
     let
-        borderColorNormal =
-            Colors.grayMedium
         borderColorStyle =
-            case config.error of
-                Just error ->
-                    if error then Colors.redDark
-                    else borderColorNormal
-
-                Nothing ->
-                    borderColorNormal
-
+            if config.showError then Colors.redDark
+            else Colors.grayMedium
     in
     [ fontSize (rem 1)
         , height (em 2.5)

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -7,7 +7,7 @@ module Nordea.Components.TextInput exposing
     , withError
     )
 
-import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (placeholder, value)
 import Html.Styled.Events exposing (onInput)
@@ -80,11 +80,11 @@ getStyles : Config msg -> List Style
 getStyles config =
     let
         borderColorNormal =
-            borderColor Colors.grayMedium
+            Colors.grayMedium
         borderColorStyle =
             case config.error of
                 Just error ->
-                    if error then borderColor Colors.redDark
+                    if error then Colors.redDark
                     else borderColorNormal
 
                 Nothing ->
@@ -95,8 +95,7 @@ getStyles config =
         , height (em 2.5)
         , padding2 (em 0.75) (em 0.75)
         , borderRadius (em 0.125)
-        , border2 (em 0.0625) solid
-        , borderColorStyle
+        , border3 (em 0.0625) solid borderColorStyle
         , boxSizing borderBox
         , width (pct 100)
         , disabled

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -7,7 +7,7 @@ module Nordea.Components.TextInput exposing
     , withError
     )
 
-import Css exposing (Style, backgroundColor, border2, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (placeholder, value)
 import Html.Styled.Events exposing (onInput)

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -11,7 +11,7 @@ import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, bo
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (placeholder, value)
 import Html.Styled.Events exposing (onInput)
-import Maybe.Extra as Maybe exposing (isJust)
+import Maybe.Extra as Maybe
 import Nordea.Resources.Colors as Colors
 
 
@@ -79,11 +79,17 @@ getAttributes config =
 getStyles : Config msg -> List Style
 getStyles config =
     let
+        borderColorNormal =
+            borderColor Colors.grayMedium
         borderColorStyle =
-           if isJust config.error then
-                borderColor Colors.redDark
-            else
-                borderColor Colors.grayMedium
+            case config.error of
+                Just error ->
+                    if error then borderColor Colors.redDark
+                    else borderColorNormal
+
+                Nothing ->
+                    borderColorNormal
+
     in
     [ fontSize (rem 1)
         , height (em 2.5)

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -2,9 +2,9 @@ module Nordea.Components.TextInput exposing
     ( TextInput
     , init
     , view
+    , withError
     , withOnInput
     , withPlaceholder
-    , withError
     )
 
 import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
@@ -50,6 +50,7 @@ withPlaceholder : String -> TextInput msg -> TextInput msg
 withPlaceholder placeholder (TextInput config) =
     TextInput { config | placeholder = Just placeholder }
 
+
 withError : Bool -> TextInput msg -> TextInput msg
 withError condition (TextInput config) =
     TextInput { config | showError = condition }
@@ -75,27 +76,33 @@ getAttributes config =
         , config.placeholder |> Maybe.map placeholder
         ]
 
+
+
 -- STYLES
+
+
 getStyles : Config msg -> List Style
 getStyles config =
     let
         borderColorStyle =
-            if config.showError then Colors.redDark
-            else Colors.grayMedium
+            if config.showError then
+                Colors.redDark
+
+            else
+                Colors.grayMedium
     in
     [ fontSize (rem 1)
-        , height (em 2.5)
-        , padding2 (em 0.75) (em 0.75)
-        , borderRadius (em 0.125)
-        , border3 (em 0.0625) solid borderColorStyle
-        , boxSizing borderBox
-        , width (pct 100)
-        , disabled
-            [ backgroundColor Colors.grayWarm
-            ]
-        , focus
-            [ outline none
-            , borderColor Colors.blueNordea
-            ]
+    , height (em 2.5)
+    , padding2 (em 0.75) (em 0.75)
+    , borderRadius (em 0.125)
+    , border3 (em 0.0625) solid borderColorStyle
+    , boxSizing borderBox
+    , width (pct 100)
+    , disabled
+        [ backgroundColor Colors.grayWarm
         ]
-
+    , focus
+        [ outline none
+        , borderColor Colors.blueNordea
+        ]
+    ]

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -4,34 +4,14 @@ module Nordea.Components.TextInput exposing
     , view
     , withOnInput
     , withPlaceholder
+    , withError
     )
 
-import Css
-    exposing
-        ( Style
-        , backgroundColor
-        , border3
-        , borderBox
-        , borderColor
-        , borderRadius
-        , boxSizing
-        , disabled
-        , em
-        , focus
-        , fontSize
-        , height
-        , none
-        , outline
-        , padding2
-        , pct
-        , rem
-        , solid
-        , width
-        )
+import Css exposing (Style, backgroundColor, border2, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (placeholder, value)
 import Html.Styled.Events exposing (onInput)
-import Maybe.Extra as Maybe
+import Maybe.Extra as Maybe exposing (isJust)
 import Nordea.Resources.Colors as Colors
 
 
@@ -43,6 +23,7 @@ type alias Config msg =
     { value : String
     , onInput : Maybe (String -> msg)
     , placeholder : Maybe String
+    , error : Maybe Bool
     }
 
 
@@ -56,6 +37,7 @@ init value =
         { value = value
         , onInput = Nothing
         , placeholder = Nothing
+        , error = Nothing
         }
 
 
@@ -68,6 +50,10 @@ withPlaceholder : String -> TextInput msg -> TextInput msg
 withPlaceholder placeholder (TextInput config) =
     TextInput { config | placeholder = Just placeholder }
 
+withError : Bool -> TextInput msg -> TextInput msg
+withError condition (TextInput config) =
+    TextInput { config | error = Just condition }
+
 
 
 -- VIEW
@@ -76,7 +62,7 @@ withPlaceholder placeholder (TextInput config) =
 view : List (Attribute msg) -> TextInput msg -> Html msg
 view attributes (TextInput config) =
     styled input
-        styles
+        (getStyles config)
         (getAttributes config ++ attributes)
         []
 
@@ -89,25 +75,30 @@ getAttributes config =
         , config.placeholder |> Maybe.map placeholder
         ]
 
-
-
 -- STYLES
-
-
-styles : List Style
-styles =
+getStyles : Config msg -> List Style
+getStyles config =
+    let
+        borderColorStyle =
+           if isJust config.error then
+                borderColor Colors.redDark
+            else
+                borderColor Colors.grayMedium
+    in
     [ fontSize (rem 1)
-    , height (em 2.5)
-    , padding2 (em 0.75) (em 0.75)
-    , borderRadius (em 0.125)
-    , border3 (em 0.0625) solid Colors.grayMedium
-    , boxSizing borderBox
-    , width (pct 100)
-    , disabled
-        [ backgroundColor Colors.grayWarm
+        , height (em 2.5)
+        , padding2 (em 0.75) (em 0.75)
+        , borderRadius (em 0.125)
+        , border2 (em 0.0625) solid
+        , borderColorStyle
+        , boxSizing borderBox
+        , width (pct 100)
+        , disabled
+            [ backgroundColor Colors.grayWarm
+            ]
+        , focus
+            [ outline none
+            , borderColor Colors.blueNordea
+            ]
         ]
-    , focus
-        [ outline none
-        , borderColor Colors.blueNordea
-        ]
-    ]
+


### PR DESCRIPTION
As a step closer to getting full error handling on text input I have added red border when withError is set to True.

<img width="1409" alt="Screen Shot 2021-06-28 at 8 59 05 AM" src="https://user-images.githubusercontent.com/1861340/123593780-39189500-d7ef-11eb-9fa6-e1c3001bd455.png">
<img width="1408" alt="Screen Shot 2021-06-28 at 8 59 10 AM" src="https://user-images.githubusercontent.com/1861340/123593775-37e76800-d7ef-11eb-9aa8-cc3997fbfd5a.png">

