### PR TITLE
Error border on NumberInput and Dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 
 # Desktop Services Store on macOS
 .DS_Store
+
+.idea/

--- a/explorer/src/Stories/Dropdown.elm
+++ b/explorer/src/Stories/Dropdown.elm
@@ -20,4 +20,16 @@ stories =
                     |> Dropdown.view []
           , {}
           )
+          , ( "Error"
+                      , \_ ->
+                            Dropdown.init
+                                "no"
+                                [ { value = "no", label = "Norway" }
+                                , { value = "se", label = "Sweden" }
+                                , { value = "dk", label = "Denmark" }
+                                ]
+                                |> Dropdown.withError True
+                                |> Dropdown.view []
+                      , {}
+                      )
         ]

--- a/explorer/src/Stories/Dropdown.elm
+++ b/explorer/src/Stories/Dropdown.elm
@@ -20,16 +20,16 @@ stories =
                     |> Dropdown.view []
           , {}
           )
-          , ( "Error"
-                      , \_ ->
-                            Dropdown.init
-                                "no"
-                                [ { value = "no", label = "Norway" }
-                                , { value = "se", label = "Sweden" }
-                                , { value = "dk", label = "Denmark" }
-                                ]
-                                |> Dropdown.withError True
-                                |> Dropdown.view []
-                      , {}
-                      )
+        , ( "Error"
+          , \_ ->
+                Dropdown.init
+                    "no"
+                    [ { value = "no", label = "Norway" }
+                    , { value = "se", label = "Sweden" }
+                    , { value = "dk", label = "Denmark" }
+                    ]
+                    |> Dropdown.withError True
+                    |> Dropdown.view []
+          , {}
+          )
         ]

--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -39,4 +39,11 @@ stories =
                     |> NumberInput.view []
           , {}
           )
+          , ( "Error"
+            , \_ ->
+                  NumberInput.init "0"
+                      |> NumberInput.withError True
+                      |> NumberInput.view []
+            , {}
+            )
         ]

--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -39,11 +39,11 @@ stories =
                     |> NumberInput.view []
           , {}
           )
-          , ( "Error"
-            , \_ ->
-                  NumberInput.init "0"
-                      |> NumberInput.withError True
-                      |> NumberInput.view []
-            , {}
-            )
+        , ( "Error"
+          , \_ ->
+                NumberInput.init "0"
+                    |> NumberInput.withError True
+                    |> NumberInput.view []
+          , {}
+          )
         ]

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -7,7 +7,7 @@ module Nordea.Components.Dropdown exposing
     , withError
     )
 
-import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled as Html exposing (Attribute, Html, styled)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -30,7 +30,7 @@ type alias Config msg =
     { value : String
     , options : List Option
     , onInput : Maybe (String -> msg)
-    , error: Maybe Bool
+    , showError: Bool
     }
 
 
@@ -44,7 +44,7 @@ init value options =
         { value = value
         , options = options |> List.uniqueBy .value
         , onInput = Nothing
-        , error = Nothing
+        , showError = False
         }
 
 
@@ -54,7 +54,7 @@ withOnInput onInput (Dropdown config) =
 
 withError : Bool -> Dropdown msg -> Dropdown msg
 withError condition (Dropdown config) =
-    Dropdown { config | error = Just condition }
+    Dropdown { config | showError = condition }
 
 
 
@@ -90,25 +90,17 @@ getAttributes config =
 getStyles : Config msg -> List Style
 getStyles config =
     let
-        borderColorNormal =
-            borderColor Colors.grayMedium
         borderColorStyle =
-            case config.error of
-                Just error ->
-                    if error then
-                        borderColor Colors.redDark
-                    else
-                        borderColorNormal
-                Nothing ->
-                    borderColorNormal
+            if config.showError then
+                Colors.redDark
+            else
+                Colors.grayMedium
     in
-
     [ fontSize (rem 1)
         , height (em 2.5)
         , padding2 (em 0.5) (em 0.75)
         , borderRadius (em 0.125)
-        , border2 (em 0.0625) solid
-        , borderColorStyle
+        , border3 (em 0.0625) solid borderColorStyle
         , boxSizing borderBox
         , width (pct 100)
         , disabled

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -4,30 +4,10 @@ module Nordea.Components.Dropdown exposing
     , init
     , view
     , withOnInput
+    , withError
     )
 
-import Css
-    exposing
-        ( Style
-        , backgroundColor
-        , border3
-        , borderBox
-        , borderColor
-        , borderRadius
-        , boxSizing
-        , disabled
-        , em
-        , focus
-        , fontSize
-        , height
-        , none
-        , outline
-        , padding2
-        , pct
-        , rem
-        , solid
-        , width
-        )
+import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled as Html exposing (Attribute, Html, styled)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events
@@ -50,6 +30,7 @@ type alias Config msg =
     { value : String
     , options : List Option
     , onInput : Maybe (String -> msg)
+    , error: Maybe Bool
     }
 
 
@@ -63,12 +44,17 @@ init value options =
         { value = value
         , options = options |> List.uniqueBy .value
         , onInput = Nothing
+        , error = Nothing
         }
 
 
 withOnInput : (String -> msg) -> Dropdown msg -> Dropdown msg
 withOnInput onInput (Dropdown config) =
     Dropdown { config | onInput = Just onInput }
+
+withError : Bool -> Dropdown msg -> Dropdown msg
+withError condition (Dropdown config) =
+    Dropdown { config | error = Just condition }
 
 
 
@@ -78,7 +64,7 @@ withOnInput onInput (Dropdown config) =
 view : List (Attribute msg) -> Dropdown msg -> Html msg
 view attributes (Dropdown config) =
     styled Html.select
-        styles
+        (getStyles config)
         (getAttributes config ++ attributes)
         (List.map (viewOption config.value) config.options)
 
@@ -101,21 +87,35 @@ getAttributes config =
 
 -- STYLES
 
+getStyles : Config msg -> List Style
+getStyles config =
+    let
+        borderColorNormal =
+            borderColor Colors.grayMedium
+        borderColorStyle =
+            case config.error of
+                Just error ->
+                    if error then
+                        borderColor Colors.redDark
+                    else
+                        borderColorNormal
+                Nothing ->
+                    borderColorNormal
+    in
 
-styles : List Style
-styles =
     [ fontSize (rem 1)
-    , height (em 2.5)
-    , padding2 (em 0.5) (em 0.75)
-    , borderRadius (em 0.125)
-    , border3 (em 0.0625) solid Colors.grayMedium
-    , boxSizing borderBox
-    , width (pct 100)
-    , disabled
-        [ backgroundColor Colors.grayWarm
+        , height (em 2.5)
+        , padding2 (em 0.5) (em 0.75)
+        , borderRadius (em 0.125)
+        , border2 (em 0.0625) solid
+        , borderColorStyle
+        , boxSizing borderBox
+        , width (pct 100)
+        , disabled
+            [ backgroundColor Colors.grayWarm
+            ]
+        , focus
+            [ outline none
+            , borderColor Colors.blueNordea
+            ]
         ]
-    , focus
-        [ outline none
-        , borderColor Colors.blueNordea
-        ]
-    ]

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -7,7 +7,28 @@ module Nordea.Components.Dropdown exposing
     , withOnInput
     )
 
-import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css
+    exposing
+        ( Style
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderColor
+        , borderRadius
+        , boxSizing
+        , disabled
+        , em
+        , focus
+        , fontSize
+        , height
+        , none
+        , outline
+        , padding2
+        , pct
+        , rem
+        , solid
+        , width
+        )
 import Html.Styled as Html exposing (Attribute, Html, styled)
 import Html.Styled.Attributes as Attributes
 import Html.Styled.Events as Events

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -3,8 +3,8 @@ module Nordea.Components.Dropdown exposing
     , Option
     , init
     , view
-    , withOnInput
     , withError
+    , withOnInput
     )
 
 import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
@@ -30,7 +30,7 @@ type alias Config msg =
     { value : String
     , options : List Option
     , onInput : Maybe (String -> msg)
-    , showError: Bool
+    , showError : Bool
     }
 
 
@@ -51,6 +51,7 @@ init value options =
 withOnInput : (String -> msg) -> Dropdown msg -> Dropdown msg
 withOnInput onInput (Dropdown config) =
     Dropdown { config | onInput = Just onInput }
+
 
 withError : Bool -> Dropdown msg -> Dropdown msg
 withError condition (Dropdown config) =
@@ -87,27 +88,29 @@ getAttributes config =
 
 -- STYLES
 
+
 getStyles : Config msg -> List Style
 getStyles config =
     let
         borderColorStyle =
             if config.showError then
                 Colors.redDark
+
             else
                 Colors.grayMedium
     in
     [ fontSize (rem 1)
-        , height (em 2.5)
-        , padding2 (em 0.5) (em 0.75)
-        , borderRadius (em 0.125)
-        , border3 (em 0.0625) solid borderColorStyle
-        , boxSizing borderBox
-        , width (pct 100)
-        , disabled
-            [ backgroundColor Colors.grayWarm
-            ]
-        , focus
-            [ outline none
-            , borderColor Colors.blueNordea
-            ]
+    , height (em 2.5)
+    , padding2 (em 0.5) (em 0.75)
+    , borderRadius (em 0.125)
+    , border3 (em 0.0625) solid borderColorStyle
+    , boxSizing borderBox
+    , width (pct 100)
+    , disabled
+        [ backgroundColor Colors.grayWarm
         ]
+    , focus
+        [ outline none
+        , borderColor Colors.blueNordea
+        ]
+    ]

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -111,7 +111,7 @@ getAttributes config =
 getStyles : Config msg -> List Style
 getStyles config =
     let
-        borderColorStyleNormal =
+        borderColorNormal =
             borderColor Colors.grayMedium
         borderColorStyle =
             case config.error of
@@ -119,9 +119,9 @@ getStyles config =
                     if error then
                         borderColor Colors.redDark
                     else
-                        borderColorStyleNormal
+                        borderColorNormal
                 Nothing ->
-                    borderColorStyleNormal
+                    borderColorNormal
     in
 
     [ fontSize (rem 1)

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -1,5 +1,5 @@
 module Nordea.Components.NumberInput exposing
-    ( TextInput
+    ( NumberInput
     , init
     , view
     , withMax
@@ -7,34 +7,14 @@ module Nordea.Components.NumberInput exposing
     , withOnInput
     , withPlaceholder
     , withStep
+    , withError
     )
 
-import Css
-    exposing
-        ( Style
-        , backgroundColor
-        , border3
-        , borderBox
-        , borderColor
-        , borderRadius
-        , boxSizing
-        , disabled
-        , em
-        , focus
-        , fontSize
-        , height
-        , none
-        , outline
-        , padding2
-        , pct
-        , rem
-        , solid
-        , width
-        )
+import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (placeholder, step, type_, value)
 import Html.Styled.Events exposing (onInput)
-import Maybe.Extra as Maybe
+import Maybe.Extra as Maybe exposing (isJust)
 import Nordea.Resources.Colors as Colors
 
 
@@ -49,14 +29,15 @@ type alias Config msg =
     , step : Maybe Float
     , placeholder : Maybe String
     , onInput : Maybe (String -> msg)
+    , error: Maybe Bool
     }
 
 
-type TextInput msg
+type NumberInput msg
     = NumberInput (Config msg)
 
 
-init : String -> TextInput msg
+init : String -> NumberInput msg
 init value =
     NumberInput
         { value = value
@@ -65,42 +46,47 @@ init value =
         , step = Nothing
         , placeholder = Nothing
         , onInput = Nothing
+        , error = Nothing
         }
 
 
-withMin : Float -> TextInput msg -> TextInput msg
+withMin : Float -> NumberInput msg -> NumberInput msg
 withMin min (NumberInput config) =
     NumberInput { config | min = Just min }
 
 
-withMax : Float -> TextInput msg -> TextInput msg
+withMax : Float -> NumberInput msg -> NumberInput msg
 withMax max (NumberInput config) =
     NumberInput { config | max = Just max }
 
 
-withStep : Float -> TextInput msg -> TextInput msg
+withStep : Float -> NumberInput msg -> NumberInput msg
 withStep step (NumberInput config) =
     NumberInput { config | step = Just step }
 
 
-withPlaceholder : String -> TextInput msg -> TextInput msg
+withPlaceholder : String -> NumberInput msg -> NumberInput msg
 withPlaceholder placeholder (NumberInput config) =
     NumberInput { config | placeholder = Just placeholder }
 
 
-withOnInput : (String -> msg) -> TextInput msg -> TextInput msg
+withOnInput : (String -> msg) -> NumberInput msg -> NumberInput msg
 withOnInput onInput (NumberInput config) =
     NumberInput { config | onInput = Just onInput }
+
+withError : Bool  -> NumberInput msg -> NumberInput msg
+withError condition (NumberInput config) =
+    NumberInput { config | error = Just condition }
 
 
 
 -- VIEW
 
 
-view : List (Attribute msg) -> TextInput msg -> Html msg
+view : List (Attribute msg) -> NumberInput msg -> Html msg
 view attributes (NumberInput config) =
     styled input
-        styles
+        (getStyles config)
         (getAttributes config ++ attributes)
         []
 
@@ -122,13 +108,28 @@ getAttributes config =
 -- STYLES
 
 
-styles : List Style
-styles =
+getStyles : Config msg -> List Style
+getStyles config =
+    let
+        borderColorStyleNormal =
+            borderColor Colors.grayMedium
+        borderColorStyle =
+            case config.error of
+                Just error ->
+                    if error then
+                        borderColor Colors.redDark
+                    else
+                        borderColorStyleNormal
+                Nothing ->
+                    borderColorStyleNormal
+    in
+
     [ fontSize (rem 1)
     , height (em 2.5)
     , padding2 (em 0.75) (em 0.75)
     , borderRadius (em 0.125)
-    , border3 (em 0.0625) solid Colors.grayMedium
+    , border2 (em 0.0625) solid
+    , borderColorStyle
     , boxSizing borderBox
     , width (pct 100)
     , disabled

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -10,7 +10,28 @@ module Nordea.Components.NumberInput exposing
     , withStep
     )
 
-import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css
+    exposing
+        ( Style
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderColor
+        , borderRadius
+        , boxSizing
+        , disabled
+        , em
+        , focus
+        , fontSize
+        , height
+        , none
+        , outline
+        , padding2
+        , pct
+        , rem
+        , solid
+        , width
+        )
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (placeholder, step, type_, value)
 import Html.Styled.Events exposing (onInput)

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -2,12 +2,12 @@ module Nordea.Components.NumberInput exposing
     ( NumberInput
     , init
     , view
+    , withError
     , withMax
     , withMin
     , withOnInput
     , withPlaceholder
     , withStep
-    , withError
     )
 
 import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
@@ -29,7 +29,7 @@ type alias Config msg =
     , step : Maybe Float
     , placeholder : Maybe String
     , onInput : Maybe (String -> msg)
-    , showError: Bool
+    , showError : Bool
     }
 
 
@@ -75,7 +75,7 @@ withOnInput onInput (NumberInput config) =
     NumberInput { config | onInput = Just onInput }
 
 
-withError : Bool  -> NumberInput msg -> NumberInput msg
+withError : Bool -> NumberInput msg -> NumberInput msg
 withError condition (NumberInput config) =
     NumberInput { config | showError = condition }
 
@@ -115,10 +115,10 @@ getStyles config =
         borderColorStyle =
             if config.showError then
                 Colors.redDark
+
             else
                 Colors.grayMedium
     in
-
     [ fontSize (rem 1)
     , height (em 2.5)
     , padding2 (em 0.75) (em 0.75)

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -10,11 +10,11 @@ module Nordea.Components.NumberInput exposing
     , withError
     )
 
-import Css exposing (Style, backgroundColor, border2, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (placeholder, step, type_, value)
 import Html.Styled.Events exposing (onInput)
-import Maybe.Extra as Maybe exposing (isJust)
+import Maybe.Extra as Maybe
 import Nordea.Resources.Colors as Colors
 
 
@@ -29,7 +29,7 @@ type alias Config msg =
     , step : Maybe Float
     , placeholder : Maybe String
     , onInput : Maybe (String -> msg)
-    , error: Maybe Bool
+    , showError: Bool
     }
 
 
@@ -46,7 +46,7 @@ init value =
         , step = Nothing
         , placeholder = Nothing
         , onInput = Nothing
-        , error = Nothing
+        , showError = False
         }
 
 
@@ -74,9 +74,10 @@ withOnInput : (String -> msg) -> NumberInput msg -> NumberInput msg
 withOnInput onInput (NumberInput config) =
     NumberInput { config | onInput = Just onInput }
 
+
 withError : Bool  -> NumberInput msg -> NumberInput msg
 withError condition (NumberInput config) =
-    NumberInput { config | error = Just condition }
+    NumberInput { config | showError = condition }
 
 
 
@@ -111,25 +112,18 @@ getAttributes config =
 getStyles : Config msg -> List Style
 getStyles config =
     let
-        borderColorNormal =
-            borderColor Colors.grayMedium
         borderColorStyle =
-            case config.error of
-                Just error ->
-                    if error then
-                        borderColor Colors.redDark
-                    else
-                        borderColorNormal
-                Nothing ->
-                    borderColorNormal
+            if config.showError then
+                Colors.redDark
+            else
+                Colors.grayMedium
     in
 
     [ fontSize (rem 1)
     , height (em 2.5)
     , padding2 (em 0.75) (em 0.75)
     , borderRadius (em 0.125)
-    , border2 (em 0.0625) solid
-    , borderColorStyle
+    , border3 (em 0.0625) solid borderColorStyle
     , boxSizing borderBox
     , width (pct 100)
     , disabled


### PR DESCRIPTION
As a follow up on https://github.com/SGFinansAS/elm-components/pull/24 I have added withError on NumberInput and Dropdown, which will add an red border if an error exists


<img width="731" alt="Screen Shot 2021-06-28 at 10 57 46 AM" src="https://user-images.githubusercontent.com/1861340/123609325-da0f4c00-d7ff-11eb-97b0-25d978840c15.png">
<img width="745" alt="Screen Shot 2021-06-28 at 10 57 43 AM" src="https://user-images.githubusercontent.com/1861340/123609331-daa7e280-d7ff-11eb-9cfb-86f6425f400f.png">

<img width="715" alt="Screen Shot 2021-06-28 at 10 57 51 AM" src="https://user-images.githubusercontent.com/1861340/123609322-d976b580-d7ff-11eb-8869-8a5dcc8f334f.png">
<img width="711" alt="Screen Shot 2021-06-28 at 10 57 55 AM" src="https://user-images.githubusercontent.com/1861340/123609317-d8de1f00-d7ff-11eb-960b-d197f2753d51.png">
