### PR TITLE
Adding error borders to radio and checkbox

### DIFF
--- a/explorer/src/Stories/Checkbox.elm
+++ b/explorer/src/Stories/Checkbox.elm
@@ -16,4 +16,11 @@ stories =
                     |> Checkbox.view [] [ text "Click me" ]
           , {}
           )
+        , ( "Error"
+          , \_ ->
+                Checkbox.init False
+                    |> Checkbox.withError True
+                    |> Checkbox.view [] [ text "Click me" ]
+          , {}
+          )
         ]

--- a/explorer/src/Stories/RadioButton.elm
+++ b/explorer/src/Stories/RadioButton.elm
@@ -30,4 +30,24 @@ stories =
                     ]
           , {}
           )
+        , ( "Error"
+          , \_ ->
+                Html.div []
+                    [ Html.styled Html.div
+                        [ Css.margin2 (Css.rem 0.5) Css.zero ]
+                        []
+                        [ RadioButton.init False
+                            |> RadioButton.withError True
+                            |> RadioButton.view [ Attrs.name "radio" ] [ text "Answer 1" ]
+                        ]
+                    , Html.styled Html.div
+                        [ Css.margin2 (Css.rem 0.5) Css.zero ]
+                        []
+                        [ RadioButton.init False
+                            |> RadioButton.withError True
+                            |> RadioButton.view [ Attrs.name "radio" ] [ text "Answer 2" ]
+                        ]
+                    ]
+          , {}
+          )
         ]

--- a/src/Nordea/Components/Checkbox.elm
+++ b/src/Nordea/Components/Checkbox.elm
@@ -1,4 +1,4 @@
-module Nordea.Components.Checkbox exposing (Checkbox, init, view, withOnCheck)
+module Nordea.Components.Checkbox exposing (Checkbox, init, view, withError, withOnCheck)
 
 import Css
     exposing
@@ -35,6 +35,7 @@ import Nordea.Resources.Icons as Icons
 type alias Config msg =
     { checked : Bool
     , onCheck : Maybe (Bool -> msg)
+    , showError : Bool
     }
 
 
@@ -51,12 +52,18 @@ init checked =
     Checkbox
         { checked = checked
         , onCheck = Nothing
+        , showError = False
         }
 
 
 withOnCheck : (Bool -> msg) -> Checkbox msg -> Checkbox msg
 withOnCheck onCheck (Checkbox config) =
     Checkbox { config | onCheck = Just onCheck }
+
+
+withError : Bool -> Checkbox msg -> Checkbox msg
+withError condition (Checkbox config) =
+    Checkbox { config | showError = condition }
 
 
 
@@ -73,7 +80,7 @@ view attributes children (Checkbox config) =
             (inputAttributes config ++ attributes)
             []
          , styled div
-            boxStyles
+            (boxStyles config)
             []
             [ Icons.check ]
          ]
@@ -111,13 +118,21 @@ inputStyles =
     ]
 
 
-boxStyles : List Style
-boxStyles =
+boxStyles : Config msg -> List Style
+boxStyles config =
+    let
+        borderColorStyle =
+            if config.showError then
+                Colors.redDark
+
+            else
+                Colors.blueDeep
+    in
     [ display inlineBlock
     , width (em 1)
     , height (em 1)
     , boxSizing contentBox
-    , border3 (em 0.125) solid Colors.blueDeep
+    , border3 (em 0.125) solid borderColorStyle
     , backgroundColor Colors.white
     , color Colors.white
     , marginRight (em 0.5)

--- a/src/Nordea/Components/RadioButton.elm
+++ b/src/Nordea/Components/RadioButton.elm
@@ -1,6 +1,12 @@
-module Nordea.Components.RadioButton exposing (RadioButton, init, view, withOnCheck)
+module Nordea.Components.RadioButton exposing
+    ( RadioButton
+    , init
+    , view
+    , withError
+    , withOnCheck
+    )
 
-import Css
+import Css exposing (Style)
 import Css.Global as Css
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attrs
@@ -12,6 +18,7 @@ import Nordea.Resources.Colors as Colors
 type alias Config msg =
     { checked : Bool
     , onCheck : Maybe (Bool -> msg)
+    , showError : Bool
     }
 
 
@@ -28,6 +35,7 @@ init checked =
     RadioButton
         { checked = checked
         , onCheck = Nothing
+        , showError = False
         }
 
 
@@ -36,13 +44,18 @@ withOnCheck onCheck (RadioButton config) =
     RadioButton { config | onCheck = Just onCheck }
 
 
+withError : Bool -> RadioButton msg -> RadioButton msg
+withError condition (RadioButton config) =
+    RadioButton { config | showError = condition }
+
+
 
 -- VIEW
 
 
 view : List (Attribute msg) -> List (Html msg) -> RadioButton msg -> Html msg
 view attributes children (RadioButton config) =
-    viewLabel (viewInput config attributes :: (viewRadio :: children))
+    viewLabel (viewInput config attributes :: (viewRadio config :: children))
 
 
 viewLabel : List (Html msg) -> Html msg
@@ -81,28 +94,41 @@ viewInput config attributes =
         []
 
 
-viewRadio : Html msg
-viewRadio =
+viewRadio : Config msg -> Html msg
+viewRadio config =
     Html.styled Html.span
-        [ Css.before
-            [ Css.property "content" "\"\""
-            , Css.position Css.absolute
-            , Css.top Css.zero
-            , Css.left Css.zero
-            , Css.width (Css.rem 1.25)
-            , Css.height (Css.rem 1.25)
-            , Css.border3 (Css.rem 0.125) Css.solid Colors.blueDeep
-            , Css.borderRadius (Css.pct 50)
-            ]
-        , Css.after
-            [ Css.property "content" "\"\""
-            , Css.position Css.absolute
-            , Css.top (Css.rem 0.25)
-            , Css.left (Css.rem 0.25)
-            , Css.width (Css.rem 0.75)
-            , Css.height (Css.rem 0.75)
-            , Css.borderRadius (Css.pct 50)
-            ]
+        (getStyles config)
+        []
+        []
+
+
+getStyles : Config msg -> List Style
+getStyles config =
+    let
+        borderColorStyle =
+            if config.showError then
+                Colors.redDark
+
+            else
+                Colors.blueDeep
+    in
+    [ Css.before
+        [ Css.property "content" "\"\""
+        , Css.position Css.absolute
+        , Css.top Css.zero
+        , Css.left Css.zero
+        , Css.width (Css.rem 1.25)
+        , Css.height (Css.rem 1.25)
+        , Css.border3 (Css.rem 0.125) Css.solid borderColorStyle
+        , Css.borderRadius (Css.pct 50)
         ]
-        []
-        []
+    , Css.after
+        [ Css.property "content" "\"\""
+        , Css.position Css.absolute
+        , Css.top (Css.rem 0.25)
+        , Css.left (Css.rem 0.25)
+        , Css.width (Css.rem 0.75)
+        , Css.height (Css.rem 0.75)
+        , Css.borderRadius (Css.pct 50)
+        ]
+    ]


### PR DESCRIPTION
Adding error borders to radiobuttons and checkboxes. 
Later, when implementing the concept of a radio group we might add functionality to set error to a whole group.

<img width="157" alt="Screen Shot 2021-06-28 at 12 52 08 PM" src="https://user-images.githubusercontent.com/1861340/123625423-0763f600-d810-11eb-9f9f-cf29a9199db2.png">
<img width="167" alt="Screen Shot 2021-06-28 at 12 52 05 PM" src="https://user-images.githubusercontent.com/1861340/123625430-07fc8c80-d810-11eb-82c4-254fa3bf08f0.png">
<img width="146" alt="Screen Shot 2021-06-28 at 12 51 51 PM" src="https://user-images.githubusercontent.com/1861340/123625433-08952300-d810-11eb-8e34-451afc54b17b.png">
<img width="236" alt="Screen Shot 2021-06-28 at 12 51 47 PM" src="https://user-images.githubusercontent.com/1861340/123625434-08952300-d810-11eb-87b0-69a0bb7b2704.png">
