### PR TITLE
Remove unnesessary padding

### DIFF
--- a/src/Nordea/Components/InformationBox.elm
+++ b/src/Nordea/Components/InformationBox.elm
@@ -1,1 +1,0 @@
-module Nordea.Components.InformationBox exposing (..)

--- a/src/Nordea/Components/InformationBox.elm
+++ b/src/Nordea/Components/InformationBox.elm
@@ -1,0 +1,1 @@
+module Nordea.Components.InformationBox exposing (..)

--- a/src/Nordea/Components/StepIndicator.elm
+++ b/src/Nordea/Components/StepIndicator.elm
@@ -4,7 +4,41 @@ module Nordea.Components.StepIndicator exposing
     , view
     )
 
-import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, color, column, displayFlex, flexDirection, fontSize, fontWeight, height, int, justifyContent, lineHeight, listStyleType, margin, none, paddingLeft, pct, position, px, relative, rem, solid, textAlign, top, width, zIndex)
+import Css
+    exposing
+        ( Style
+        , absolute
+        , alignItems
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderRadius
+        , boxSizing
+        , center
+        , color
+        , column
+        , displayFlex
+        , flexDirection
+        , fontSize
+        , fontWeight
+        , height
+        , int
+        , justifyContent
+        , lineHeight
+        , listStyleType
+        , margin
+        , none
+        , paddingLeft
+        , pct
+        , position
+        , relative
+        , rem
+        , solid
+        , textAlign
+        , top
+        , width
+        , zIndex
+        )
 import Html.Styled exposing (Html, div, li, ol, p, span, styled, text)
 import Html.Styled.Attributes exposing (attribute)
 import Nordea.Html exposing (showIf)
@@ -87,7 +121,7 @@ listStyles =
     [ displayFlex
     , listStyleType none
     , alignItems center
-    , paddingLeft (px 0)
+    , paddingLeft (rem 0)
     ]
 
 

--- a/src/Nordea/Components/StepIndicator.elm
+++ b/src/Nordea/Components/StepIndicator.elm
@@ -4,43 +4,9 @@ module Nordea.Components.StepIndicator exposing
     , view
     )
 
-import Css
-    exposing
-        ( Style
-        , absolute
-        , alignItems
-        , backgroundColor
-        , border3
-        , borderBox
-        , borderRadius
-        , boxSizing
-        , center
-        , color
-        , column
-        , displayFlex
-        , flexDirection
-        , fontSize
-        , fontWeight
-        , height
-        , int
-        , justifyContent
-        , lineHeight
-        , listStyleType
-        , margin
-        , none
-        , pct
-        , position
-        , relative
-        , rem
-        , solid
-        , textAlign
-        , top
-        , width
-        , zIndex
-        )
+import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, color, column, displayFlex, flexDirection, fontSize, fontWeight, height, int, justifyContent, lineHeight, listStyleType, margin, none, paddingLeft, pct, position, px, relative, rem, solid, textAlign, top, width, zIndex)
 import Html.Styled exposing (Html, div, li, ol, p, span, styled, text)
 import Html.Styled.Attributes exposing (attribute)
-import List.Extra as List
 import Nordea.Html exposing (showIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.Fonts as Fonts
@@ -121,6 +87,7 @@ listStyles =
     [ displayFlex
     , listStyleType none
     , alignItems center
+    , paddingLeft (px 0)
     ]
 
 


### PR DESCRIPTION
Remove padding coming naturally from list, which will center the step indicator better

<img width="484" alt="Screen Shot 2021-10-04 at 10 58 01 AM" src="https://user-images.githubusercontent.com/1861340/135823338-799f171f-5013-4f47-8033-1941fc9eaa97.png">
