### PR TITLE
Add box sizing to fix radio button styling

### DIFF
--- a/src/Nordea/Components/RadioButton.elm
+++ b/src/Nordea/Components/RadioButton.elm
@@ -9,53 +9,7 @@ module Nordea.Components.RadioButton exposing
     , withOnBlur
     )
 
-import Css
-    exposing
-        ( absolute
-        , after
-        , alignItems
-        , backgroundColor
-        , before
-        , block
-        , border3
-        , borderBottomColor
-        , borderBottomLeftRadius
-        , borderBottomRightRadius
-        , borderColor
-        , borderRadius
-        , borderTopColor
-        , borderTopLeftRadius
-        , borderTopRightRadius
-        , boxShadow5
-        , center
-        , cursor
-        , display
-        , firstOfType
-        , flex
-        , flexBasis
-        , height
-        , hover
-        , inlineFlex
-        , int
-        , lastOfType
-        , left
-        , marginTop
-        , none
-        , num
-        , opacity
-        , padding2
-        , pct
-        , pointer
-        , position
-        , pseudoClass
-        , relative
-        , rem
-        , solid
-        , top
-        , transparent
-        , width
-        , zIndex
-        )
+import Css exposing (absolute, after, alignItems, backgroundColor, before, block, border3, borderBottomColor, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderColor, borderRadius, borderTopColor, borderTopLeftRadius, borderTopRightRadius, boxShadow5, boxSizing, center, cursor, display, firstOfType, flex, flexBasis, height, hover, inlineFlex, int, lastOfType, left, marginTop, none, num, opacity, padding2, pct, pointer, position, pseudoClass, relative, rem, solid, top, transparent, width, zIndex)
 import Css.Transitions exposing (transition)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attrs exposing (css, name, type_)
@@ -124,6 +78,7 @@ view attrs (RadioButton config) =
                         , borderColor Colors.grayMedium
                             |> styleIf (config.showError && List.member config.appearance [ Standard, ListStyle ])
                         , borderRadius (pct 100)
+                        , boxSizing borderBox
                         ]
                     , after
                         [ Css.property "content" "''"


### PR DESCRIPTION
Before adding box sizing
<img width="251" alt="Screen Shot 2021-10-13 at 1 15 10 PM" src="https://user-images.githubusercontent.com/1861340/137123587-3da2aa74-1943-49df-8950-39a0dd0fe422.png">

After adding box sizing
<img width="728" alt="Screen Shot 2021-10-13 at 1 14 56 PM" src="https://user-images.githubusercontent.com/1861340/137123627-9e70edc1-bd06-4530-a473-cc65c235adfc.png">
