### PR TITLE
Add box sizing in step indicator

### DIFF
--- a/src/Nordea/Components/StepIndicator.elm
+++ b/src/Nordea/Components/StepIndicator.elm
@@ -156,6 +156,7 @@ divStyles =
     , width (rem 2)
     , borderRadius (pct 50)
     , border3 (rem 0.125) solid Colors.grayMedium
+    , boxSizing borderBox
     , fontSize (rem 1)
     , color Colors.grayEclipse
     , backgroundColor Colors.white


### PR DESCRIPTION
Was 
![image](https://user-images.githubusercontent.com/46669977/137675212-17839dfd-1a45-4a44-927b-d1e736fc5b76.png)

Will be
![image](https://user-images.githubusercontent.com/46669977/137675235-7e1c0df3-af8c-4ee9-b53d-ecf4b8fdf94e.png)
