### PR TITLE
PAR-989 Reduce box shadow for secondary button

### DIFF
--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -163,7 +163,7 @@ variantStyle variant =
                     [ outline none
                     , Themes.backgroundColor Themes.SecondaryColor Colors.blueCloud
                     , Themes.color Themes.PrimaryColor Colors.blueDeep
-                    , Css.property "box-shadow" ("0rem 0rem 0rem 0.25rem " ++ Themes.colorVariable Themes.PrimaryColor Colors.blueDeep)
+                    , Css.property "box-shadow" ("0rem 0rem 0rem 0.125rem " ++ Themes.colorVariable Themes.PrimaryColor Colors.blueDeep)
                     ]
                 ]
 


### PR DESCRIPTION
Secondary button's border and box shadow has same color `deepBlue` so looks like huge border on focus. 
Reduced the border's width from box shadow.