### PR TITLE
Add box sizing to active elements in step indicator

### DIFF
--- a/src/Nordea/Components/StepIndicator.elm
+++ b/src/Nordea/Components/StepIndicator.elm
@@ -190,6 +190,7 @@ divStylesActive =
     , borderRadius (pct 50)
     , border3 (rem 0.125) solid Colors.white
     , Themes.backgroundColor Themes.PrimaryColor Colors.blueDeep
+    , boxSizing borderBox
     , color Colors.white
     ]
 


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/1189327/139845316-0b447d0d-f84d-4546-85e1-87a35e8a39f6.png)

# After
![image](https://user-images.githubusercontent.com/1189327/139845339-288a430f-d3be-4e42-8899-48256f87df62.png)
