### PR TITLE
PAR-673: Add card button.

### DIFF
--- a/explorer/src/Stories/Button.elm
+++ b/explorer/src/Stories/Button.elm
@@ -1,6 +1,16 @@
 module Stories.Button exposing (stories)
 
-import Css exposing (marginBottom, rem)
+import Css
+    exposing
+        ( column
+        , flexDirection
+        , justifyContent
+        , marginBottom
+        , minHeight
+        , rem
+        , spaceBetween
+        , width
+        )
 import Css.Global exposing (children, everything)
 import Html.Styled as Html exposing (text)
 import Html.Styled.Attributes exposing (css, disabled)
@@ -59,6 +69,24 @@ stories =
                         |> Button.view [] [ text "Click me", Icons.rightIcon Icons.info ]
                     , Button.tertiary
                         |> Button.view [] [ Icons.leftIcon Icons.info, text "Click me" ]
+                    ]
+          , {}
+          )
+        , ( "Card (WIP)"
+          , \_ ->
+                Html.div [ css [ children [ everything [ marginBottom (rem 1) ] ] ] ]
+                    [ Button.card
+                        |> Button.view
+                            [ css
+                                [ width (rem 11)
+                                , minHeight (rem 8.25)
+                                , justifyContent spaceBetween
+                                , flexDirection column
+                                ]
+                            ]
+                            [ text "Click me"
+                            , Icons.rightIcon Icons.info
+                            ]
                     ]
           , {}
           )

--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -18,10 +18,10 @@ import Css
         , border3
         , borderBox
         , borderRadius
-        , boxShadow5
+        , borderStyle
+        , boxShadow4
         , boxSizing
         , center
-        , color
         , cursor
         , disabled
         , displayFlex
@@ -31,16 +31,21 @@ import Css
         , fontWeight
         , hover
         , int
+        , left
         , none
         , num
         , opacity
         , outline
+        , padding
         , padding2
         , pointer
         , pointerEvents
+        , px
         , rem
+        , scale
         , solid
-        , zero
+        , textAlign
+        , transform
         )
 import Html.Styled as Html exposing (Attribute, Html)
 import Nordea.Resources.Colors as Colors
@@ -55,6 +60,7 @@ type Variant
     = Primary
     | Secondary
     | Tertiary
+    | Card
 
 
 type alias Config =
@@ -84,6 +90,11 @@ secondary =
 tertiary : Button
 tertiary =
     init Tertiary
+
+
+card : Button
+card =
+    init Card
 
 
 withStyles : List Style -> Button -> Button
@@ -182,6 +193,17 @@ variantStyle variant =
                     , Themes.color Themes.PrimaryColor Colors.blueDeep
                     , Css.property "box-shadow" ("0rem 0rem 0rem 0.25rem " ++ Themes.colorVariable Themes.SecondaryColor Colors.blueHaas)
                     ]
+                ]
+
+        Card ->
+            batch
+                [ backgroundColor Colors.white
+                , textAlign left
+                , padding (rem 1)
+                , borderRadius (rem 0.75)
+                , borderStyle none
+                , boxShadow4 (rem 0) (px 4) (px 40) Colors.grayLight
+                , hover [ transform (scale 1.25) ]
                 ]
 
 

--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -2,6 +2,7 @@ module Nordea.Components.Button exposing
     ( Button
     , Variant(..)
     , buttonStyleForExport
+    , card
     , primary
     , secondary
     , tertiary
@@ -40,7 +41,6 @@ import Css
         , padding2
         , pointer
         , pointerEvents
-        , px
         , rem
         , scale
         , solid
@@ -202,7 +202,7 @@ variantStyle variant =
                 , padding (rem 1)
                 , borderRadius (rem 0.75)
                 , borderStyle none
-                , boxShadow4 (rem 0) (px 4) (px 40) Colors.grayLight
+                , boxShadow4 (rem 0) (rem 0.25) (rem 2.5) Colors.grayLight
                 , hover [ transform (scale 1.25) ]
                 ]
 


### PR DESCRIPTION
- Adds a "card" button.
- This is very much a WIP, so I was hoping we could merge it, and extend it later. Design does not seem to have landed yet on how it will look in the end. Only that we'll have a card button component.

Example of how it will be usen in PartnerHub 👇
<img width="1491" alt="Screenshot 2021-11-15 at 08 10 18" src="https://user-images.githubusercontent.com/11747383/141737761-842f3de9-1a5c-4a09-8311-e1ae40866945.png">
