### PR TITLE
Add card with title and new color to component library

### DIFF
--- a/explorer/src/Explorer.elm
+++ b/explorer/src/Explorer.elm
@@ -6,6 +6,7 @@ import Html.Styled exposing (toUnstyled)
 import Nordea.Resources.Fonts as Fonts
 import Stories.Accordion as Accordion
 import Stories.Button as Button
+import Stories.Card as Card
 import Stories.Checkbox as Checkbox
 import Stories.Dropdown as Dropdown
 import Stories.FlatLink as FlatLink
@@ -61,4 +62,5 @@ main =
         , Accordion.stories
         , Spinner.stories
         , Label.stories
+        , Card.stories
         ]

--- a/explorer/src/Stories/Card.elm
+++ b/explorer/src/Stories/Card.elm
@@ -12,13 +12,21 @@ stories =
         "Card"
         [ ( "Default"
           , \_ ->
-                Card.init "Card title"
+                Card.init
                     |> Card.view [ Html.text "Card content" ]
           , {}
           )
         , ( "With shadow"
           , \_ ->
-                Card.init "Card title"
+                Card.init
+                    |> Card.withShadow
+                    |> Card.view [ Html.text "Card content" ]
+          , {}
+          )
+        , ( "With title"
+          , \_ ->
+                Card.init
+                    |> Card.withTitle "Card title"
                     |> Card.withShadow
                     |> Card.view [ Html.text "Card content" ]
           , {}

--- a/explorer/src/Stories/Card.elm
+++ b/explorer/src/Stories/Card.elm
@@ -1,0 +1,26 @@
+module Stories.Card exposing (..)
+
+import Html.Styled as Html
+import Nordea.Components.Card as Card
+import UIExplorer exposing (UI)
+import UIExplorer.Styled exposing (styledStoriesOf)
+
+
+stories : UI a b {}
+stories =
+    styledStoriesOf
+        "Card"
+        [ ( "Default"
+          , \_ ->
+                Card.init "Card title"
+                    |> Card.view [ Html.text "Card content" ]
+          , {}
+          )
+        , ( "With shadow"
+          , \_ ->
+                Card.init "Card title"
+                    |> Card.withShadow
+                    |> Card.view [ Html.text "Card content" ]
+          , {}
+          )
+        ]

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -1,14 +1,14 @@
 module Nordea.Components.Card exposing (..)
 
-import Css exposing (Style, auto, backgroundColor, border3, borderRadius, borderStyle, fontSize, height, left, margin, none, padding4, rem, solid, textAlign, width)
+import Css exposing (Style, auto, backgroundColor, border3, borderBottom3, borderRadius, borderStyle, fontSize, height, left, margin, none, padding4, rem, solid, textAlign, width)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
-import Nordea.Html exposing (styleIf)
+import Nordea.Html exposing (styleIf, viewMaybe)
 import Nordea.Resources.Colors as Colors
 
 
 type alias CardProperties =
-    { title : String
+    { title : Maybe String
     , hasShadow : Bool
     }
 
@@ -17,10 +17,10 @@ type Card msg
     = Card CardProperties
 
 
-init : String -> Card msg
-init title =
+init : Card msg
+init =
     Card
-        { title = title
+        { title = Nothing
         , hasShadow = False
         }
 
@@ -39,8 +39,7 @@ view children (Card config) =
         [ css
             cardStyle
         ]
-        [ cardTitle config.title
-        , separationLine
+        [ config.title |> viewMaybe (\title -> cardTitle title)
         , cardContentContainer
             children
         ]
@@ -52,6 +51,7 @@ cardTitle title =
         [ css
             [ cardPadding
             , fontSize (rem 1.125)
+            , borderBottom3 (rem 0.0625) solid Colors.grayCool
             ]
         ]
         [ Html.text title
@@ -69,23 +69,14 @@ cardContentContainer children =
         children
 
 
-separationLine : Html msg
-separationLine =
-    Html.hr
-        [ css
-            [ width auto
-            , borderStyle none
-            , height (rem 0.0625)
-            , backgroundColor Colors.grayCool
-            , margin (rem 0)
-            ]
-        ]
-        []
-
-
 cardPadding : Style
 cardPadding =
     padding4 (rem 2) (rem 2) (rem 1) (rem 2)
+
+
+withTitle : String -> Card msg -> Card msg
+withTitle title (Card config) =
+    Card { config | title = Just title }
 
 
 withShadow : Card msg -> Card msg

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -1,8 +1,9 @@
 module Nordea.Components.Card exposing (..)
 
-import Css exposing (Style, auto, backgroundColor, border3, borderBottom3, borderRadius, borderStyle, fontSize, height, left, margin, none, padding4, rem, solid, textAlign, width)
+import Css exposing (Style, backgroundColor, borderBottom3, borderRadius, fontSize, left, padding, padding4, rem, solid, textAlign)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
+import Maybe.Extra as Maybe
 import Nordea.Html exposing (styleIf, viewMaybe)
 import Nordea.Resources.Colors as Colors
 
@@ -41,6 +42,7 @@ view children (Card config) =
         ]
         [ config.title |> viewMaybe (\title -> cardTitle title)
         , cardContentContainer
+            (Maybe.isJust config.title)
             children
         ]
 
@@ -49,7 +51,7 @@ cardTitle : String -> Html msg
 cardTitle title =
     Html.div
         [ css
-            [ cardPadding
+            [ padding4 (rem 2) (rem 2) (rem 1) (rem 2)
             , fontSize (rem 1.125)
             , borderBottom3 (rem 0.0625) solid Colors.grayCool
             ]
@@ -58,20 +60,19 @@ cardTitle title =
         ]
 
 
-cardContentContainer : List (Html msg) -> Html msg
-cardContentContainer children =
+cardContentContainer : Bool -> List (Html msg) -> Html msg
+cardContentContainer hasTitle children =
     Html.div
         [ css
-            [ cardPadding
+            [ if hasTitle then
+                padding4 (rem 1) (rem 2) (rem 2) (rem 2)
+
+              else
+                padding (rem 2)
             , textAlign left
             ]
         ]
         children
-
-
-cardPadding : Style
-cardPadding =
-    padding4 (rem 2) (rem 2) (rem 1) (rem 2)
 
 
 withTitle : String -> Card msg -> Card msg

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -4,6 +4,7 @@ import Css exposing (Style, backgroundColor, borderBottom3, borderRadius, fontSi
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
 import Maybe.Extra as Maybe
+import Nordea.Components.Text as Text
 import Nordea.Html exposing (styleIf, viewMaybe)
 import Nordea.Resources.Colors as Colors
 
@@ -56,7 +57,8 @@ cardTitle title =
             , borderBottom3 (rem 0.0625) solid Colors.grayCool
             ]
         ]
-        [ Html.text title
+        [ Text.bodyTextHeavy
+            |> Text.view [] [ Html.text title ]
         ]
 
 

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -1,0 +1,93 @@
+module Nordea.Components.Card exposing (..)
+
+import Css exposing (Style, auto, backgroundColor, border3, borderRadius, borderStyle, fontSize, height, left, margin, none, padding4, rem, solid, textAlign, width)
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes exposing (css)
+import Nordea.Html exposing (styleIf)
+import Nordea.Resources.Colors as Colors
+
+
+type alias CardProperties =
+    { title : String
+    , hasShadow : Bool
+    }
+
+
+type Card msg
+    = Card CardProperties
+
+
+init : String -> Card msg
+init title =
+    Card
+        { title = title
+        , hasShadow = False
+        }
+
+
+view : List (Html msg) -> Card msg -> Html msg
+view children (Card config) =
+    let
+        cardStyle =
+            [ borderRadius (rem 0.5)
+            , backgroundColor Colors.white
+            , Css.boxShadow4 (rem 0) (rem 0.25) (rem 2.5) Colors.grayLight
+                |> styleIf config.hasShadow
+            ]
+    in
+    Html.div
+        [ css
+            cardStyle
+        ]
+        [ cardTitle config.title
+        , separationLine
+        , cardContentContainer
+            children
+        ]
+
+
+cardTitle : String -> Html msg
+cardTitle title =
+    Html.div
+        [ css
+            [ cardPadding
+            , fontSize (rem 1.125)
+            ]
+        ]
+        [ Html.text title
+        ]
+
+
+cardContentContainer : List (Html msg) -> Html msg
+cardContentContainer children =
+    Html.div
+        [ css
+            [ cardPadding
+            , textAlign left
+            ]
+        ]
+        children
+
+
+separationLine : Html msg
+separationLine =
+    Html.hr
+        [ css
+            [ width auto
+            , borderStyle none
+            , height (rem 0.0625)
+            , backgroundColor Colors.grayCool
+            , margin (rem 0)
+            ]
+        ]
+        []
+
+
+cardPadding : Style
+cardPadding =
+    padding4 (rem 2) (rem 2) (rem 1) (rem 2)
+
+
+withShadow : Card msg -> Card msg
+withShadow (Card config) =
+    Card { config | hasShadow = True }

--- a/src/Nordea/Resources/Colors.elm
+++ b/src/Nordea/Resources/Colors.elm
@@ -7,6 +7,7 @@ module Nordea.Resources.Colors exposing
     , blueMedium
     , blueNordea
     , gray
+    , grayCool
     , grayDark
     , grayDarkest
     , grayEclipse
@@ -94,6 +95,11 @@ grayMedium =
 grayLight : Color
 grayLight =
     hex "#E3E3E3"
+
+
+grayCool : Color
+grayCool =
+    hex "#F1F2F4"
 
 
 grayWarm : Color


### PR DESCRIPTION
Add a card with title, separation line and content to component library. To be used with or without shadow. 

Needed to add a new color to the component library, grayCool. 

We tried not to be to strict setting width/maxwidth, because we though it that might be better to set when you are using this card. 

<img width="1410" alt="Screen Shot 2021-11-16 at 11 45 59 AM" src="https://user-images.githubusercontent.com/1861340/141971914-0906e300-c654-4a23-b14d-fb537ca455f8.png">
<img width="755" alt="Screen Shot 2021-11-16 at 11 45 52 AM" src="https://user-images.githubusercontent.com/1861340/141971917-abe852c4-9be9-49ba-85a2-e5afcb140752.png">
