### PR TITLE
Added radio groups and moved some stuff from Label

### DIFF
--- a/explorer/src/Stories/Label.elm
+++ b/explorer/src/Stories/Label.elm
@@ -3,7 +3,7 @@ module Stories.Label exposing (stories)
 import Config exposing (Msg(..))
 import Css exposing (column, displayFlex, flexDirection, marginRight, maxWidth, rem)
 import Html.Styled as Html exposing (text)
-import Html.Styled.Attributes as Attrs exposing (css)
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Dropdown as Dropdown
 import Nordea.Components.Label as Label

--- a/explorer/src/Stories/RadioButton.elm
+++ b/explorer/src/Stories/RadioButton.elm
@@ -3,8 +3,9 @@ module Stories.RadioButton exposing (stories)
 import Config exposing (Msg(..))
 import Css exposing (column, displayFlex, flexDirection, maxWidth, rem)
 import Html.Styled as Html exposing (text)
-import Html.Styled.Attributes as Attrs exposing (css)
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.RadioButton as RadioButton
+import Nordea.Components.RadioGroup as RadioGroup
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -122,6 +123,47 @@ stories =
                                     |> RadioButton.view []
                             )
                     )
+          , {}
+          )
+        , ( "Group"
+          , \_ ->
+                RadioGroup.init
+                    "Group label"
+                    |> RadioGroup.view
+                        []
+                        [ RadioButton.init
+                            "simple"
+                            (text "Click me: ")
+                            NoOp
+                            |> RadioButton.view []
+                        , RadioButton.init
+                            "simple"
+                            (text "Click me: ")
+                            NoOp
+                            |> RadioButton.view []
+                        ]
+          , {}
+          )
+        , ( "Group with error"
+          , \_ ->
+                RadioGroup.init
+                    "Group label"
+                    |> RadioGroup.withErrorMessage "Some error message"
+                    |> RadioGroup.view
+                        []
+                        [ RadioButton.init
+                            "simple"
+                            (text "Click me: ")
+                            NoOp
+                            |> RadioButton.withHasError True
+                            |> RadioButton.view []
+                        , RadioButton.init
+                            "simple"
+                            (text "Click me: ")
+                            NoOp
+                            |> RadioButton.withHasError True
+                            |> RadioButton.view []
+                        ]
           , {}
           )
         ]

--- a/src/Nordea/Components/Common.elm
+++ b/src/Nordea/Components/Common.elm
@@ -1,6 +1,27 @@
 module Nordea.Components.Common exposing (..)
 
-import Css exposing (alignItems, auto, center, color, displayFlex, flex, flexBasis, fontFamilies, fontSize, justifyContent, lineHeight, marginBottom, marginLeft, marginRight, marginTop, none, pct, rem, spaceBetween)
+import Css
+    exposing
+        ( alignItems
+        , auto
+        , center
+        , color
+        , displayFlex
+        , flex
+        , flexBasis
+        , fontFamilies
+        , fontSize
+        , justifyContent
+        , lineHeight
+        , marginBottom
+        , marginLeft
+        , marginRight
+        , marginTop
+        , none
+        , pct
+        , rem
+        , spaceBetween
+        )
 import Html.Styled as Html exposing (Attribute, Html, div, styled, text)
 import Html.Styled.Attributes exposing (css)
 import Maybe.Extra as Maybe
@@ -31,6 +52,8 @@ type alias CharCounter =
     }
 
 
+{-| Should be replaced by common typography
+-}
 bodyText : List (Attribute msg) -> List (Html msg) -> Html msg
 bodyText =
     styled Html.span
@@ -52,7 +75,15 @@ bottomInfo config =
                             [ String.fromInt charCounter.current ++ "/" ++ String.fromInt charCounter.max |> text ]
                     )
     in
-    [ div [ css [ displayFlex, flexBasis (pct 100), justifyContent spaceBetween, marginTop (rem 0.5), Css.property "gap" "1rem" ] ]
+    [ div
+        [ css
+            [ displayFlex
+            , flexBasis (pct 100)
+            , justifyContent spaceBetween
+            , marginTop (rem 0.5)
+            , Css.property "gap" "1rem"
+            ]
+        ]
         [ config.errorMessage
             |> Html.viewMaybe
                 (\errText ->

--- a/src/Nordea/Components/Common.elm
+++ b/src/Nordea/Components/Common.elm
@@ -1,0 +1,130 @@
+module Nordea.Components.Common exposing (..)
+
+import Css exposing (alignItems, auto, center, color, displayFlex, flex, flexBasis, fontFamilies, fontSize, justifyContent, lineHeight, marginBottom, marginLeft, marginRight, marginTop, none, pct, rem, spaceBetween)
+import Html.Styled as Html exposing (Attribute, Html, div, styled, text)
+import Html.Styled.Attributes exposing (css)
+import Maybe.Extra as Maybe
+import Nordea.Html as Html exposing (showIf)
+import Nordea.Resources.Colors as Colors
+import Nordea.Resources.Icons as Icons
+
+
+type RequirednessHint
+    = Mandatory ({ no : String, se : String, dk : String } -> String)
+    | Optional ({ no : String, se : String, dk : String } -> String)
+    | Custom String
+
+
+type alias InputProperties =
+    { labelText : String
+    , requirednessHint : Maybe RequirednessHint
+    , showFocusOutline : Bool
+    , errorMessage : Maybe String
+    , hintText : Maybe String
+    , charCounter : Maybe CharCounter
+    }
+
+
+type alias CharCounter =
+    { current : Int
+    , max : Int
+    }
+
+
+bodyText : List (Attribute msg) -> List (Html msg) -> Html msg
+bodyText =
+    styled Html.span
+        [ fontSize (rem 0.875)
+        , fontFamilies [ "Nordea Sans Small" ]
+        , lineHeight (rem 1.5)
+        , color Colors.black
+        ]
+
+
+bottomInfo : InputProperties -> List (Html msg)
+bottomInfo config =
+    let
+        charCounterView =
+            config.charCounter
+                |> Html.viewMaybe
+                    (\charCounter ->
+                        bodyText [ css [ marginLeft auto, color Colors.grayDark |> Css.important ] ]
+                            [ String.fromInt charCounter.current ++ "/" ++ String.fromInt charCounter.max |> text ]
+                    )
+    in
+    [ div [ css [ displayFlex, flexBasis (pct 100), justifyContent spaceBetween, marginTop (rem 0.5), Css.property "gap" "1rem" ] ]
+        [ config.errorMessage
+            |> Html.viewMaybe
+                (\errText ->
+                    div
+                        [ css
+                            [ displayFlex
+                            , alignItems center
+                            , color Colors.redDark
+                            , fontSize (rem 0.875)
+                            ]
+                        ]
+                        [ Icons.error [ css [ marginRight (rem 0.5), flex none ] ]
+                        , text errText
+                        ]
+                )
+        , charCounterView
+        ]
+        |> showIf (Maybe.isJust config.errorMessage)
+    , div [ css [ displayFlex, flexBasis (pct 100), justifyContent spaceBetween, marginTop (rem 0.5), Css.property "gap" "1rem" ] ]
+        [ config.hintText
+            |> Html.viewMaybe
+                (\hintText ->
+                    Html.div [ css [ color Colors.grayDark, fontSize (rem 0.875) ] ] [ text hintText ]
+                )
+        , charCounterView |> showIf (Maybe.isNothing config.errorMessage)
+        ]
+        |> showIf (Maybe.isJust config.hintText || Maybe.isJust config.charCounter)
+    ]
+
+
+topInfo : InputProperties -> Html msg
+topInfo config =
+    let
+        textStyle =
+            if Maybe.isJust config.errorMessage then
+                color Colors.redDark |> Css.important
+
+            else
+                color Colors.black
+
+        toI18NString requirednessHint =
+            case requirednessHint of
+                Mandatory translate ->
+                    translate strings.mandatory
+
+                Optional translate ->
+                    translate strings.optional
+
+                Custom string ->
+                    string
+    in
+    div [ css [ displayFlex, justifyContent spaceBetween, marginBottom (rem 0.5) ] ]
+        [ bodyText [ css [ textStyle ] ] [ text config.labelText ]
+        , config.requirednessHint
+            |> Html.viewMaybe
+                (\requirednessHint ->
+                    bodyText
+                        [ css [ color Colors.grayDark |> Css.important ] ]
+                        [ requirednessHint |> toI18NString |> text ]
+                )
+        ]
+
+
+strings =
+    { mandatory =
+        { no = "Obligatorisk"
+        , se = "Obligatoriskt"
+        , dk = "Obligatorisk"
+        }
+    , optional =
+        { no = "Valgfritt"
+        , se = "Valfritt"
+        , dk = "Valgfrit"
+        }
+    }

--- a/src/Nordea/Components/RadioButton.elm
+++ b/src/Nordea/Components/RadioButton.elm
@@ -18,7 +18,6 @@ import Css
         , before
         , block
         , border3
-        , borderBottomColor
         , borderBottomLeftRadius
         , borderBottomRightRadius
         , borderBox
@@ -32,16 +31,15 @@ import Css
         , center
         , cursor
         , display
-        , firstOfType
+        , fitContent
         , flex
         , flexBasis
         , height
         , hover
         , inlineFlex
         , int
-        , lastOfType
         , left
-        , marginTop
+        , minWidth
         , none
         , num
         , opacity
@@ -191,6 +189,7 @@ view attrs (RadioButton config) =
             , Css.property "gap" "0.5rem"
             , alignItems center
             , cursor pointer
+            , minWidth fitContent
             , appearanceStyle
             , position relative
             , pseudoClass "hover .nfe-radiomark:before" [ Css.property "box-shadow" ("0rem 0rem 0rem 0.0625rem " ++ Themes.colorVariable Themes.SecondaryColor Colors.blueMedium) ]

--- a/src/Nordea/Components/RadioGroup.elm
+++ b/src/Nordea/Components/RadioGroup.elm
@@ -1,6 +1,6 @@
 module Nordea.Components.RadioGroup exposing (init, view, withErrorMessage)
 
-import Css exposing (displayFlex, flexDirection, flexWrap, marginBottom, rem, row, wrap)
+import Css exposing (displayFlex, flexDirection, flexWrap, lineHeight, marginBottom, rem, row, wrap)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Common as Common
@@ -27,7 +27,7 @@ init label =
 view : List (Attribute msg) -> List (Html msg) -> RadioGroup -> Html msg
 view attrs contents (RadioGroup properties) =
     Html.fieldset attrs
-        ([ Html.legend [ css [ marginBottom (rem 0.75) ] ] [ Html.text properties.label ]
+        ([ Html.legend [ css [ marginBottom (rem 0.5) ] ] [ Html.text properties.label ]
          , Html.div [ css [ displayFlex, flexWrap wrap, flexDirection row, Css.property "gap" "1rem" ] ] contents
          ]
             ++ Common.bottomInfo

--- a/src/Nordea/Components/RadioGroup.elm
+++ b/src/Nordea/Components/RadioGroup.elm
@@ -1,0 +1,46 @@
+module Nordea.Components.RadioGroup exposing (init, view, withErrorMessage)
+
+import Css exposing (displayFlex, flexDirection, flexWrap, marginBottom, rem, row, wrap)
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes exposing (css)
+import Nordea.Components.Common as Common
+
+
+type alias RadioGroupProperties =
+    { label : String
+    , errorMessage : Maybe String
+    }
+
+
+type RadioGroup
+    = RadioGroup RadioGroupProperties
+
+
+init : String -> RadioGroup
+init label =
+    RadioGroup
+        { label = label
+        , errorMessage = Nothing
+        }
+
+
+view : List (Attribute msg) -> List (Html msg) -> RadioGroup -> Html msg
+view attrs contents (RadioGroup properties) =
+    Html.fieldset attrs
+        ([ Html.legend [ css [ marginBottom (rem 0.75) ] ] [ Html.text properties.label ]
+         , Html.div [ css [ displayFlex, flexWrap wrap, flexDirection row, Css.property "gap" "1rem" ] ] contents
+         ]
+            ++ Common.bottomInfo
+                { labelText = properties.label
+                , requirednessHint = Nothing
+                , showFocusOutline = False
+                , errorMessage = properties.errorMessage
+                , hintText = Nothing
+                , charCounter = Nothing
+                }
+        )
+
+
+withErrorMessage : String -> RadioGroup -> RadioGroup
+withErrorMessage errorMessage (RadioGroup properties) =
+    RadioGroup { properties | errorMessage = Just errorMessage }


### PR DESCRIPTION
Added new component `RadioGroup` to use for grouped radio buttons.
To avoid wrapping of all groups in `Label`s we moved `bottomInfo` and `topInfo` out of `Label` and into a new `Common.elm` .
The thought is to use `topInfo` and `bottomInfo` inside the individual components instead of wrapping the components in `Label` where they are used.

To clarify: `topInfo` and `bottomInfo` will still only be used inside the `elm-components library`