### PR TITLE
Add filled chevron for dropdown

### DIFF
--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -155,16 +155,14 @@ view attrs (Dropdown config) =
                 ]
             ]
             (placeholder :: options)
-        , Icon.chevronDown
+        , Icon.chevronDownFilled
             [ css
                 [ position absolute
                 , top (pct 50)
                 , transform (translateY (pct -50))
-                , right (rem 0.75)
-                , width (rem 1.125) |> Css.important
-                , height (rem 1.125)
+                , right (rem 0.25)
                 , pointerEvents none
-                , color inherit
+                , color Colors.grayCool
                 ]
             ]
         ]

--- a/src/Nordea/Resources/Colors.elm
+++ b/src/Nordea/Resources/Colors.elm
@@ -23,6 +23,7 @@ module Nordea.Resources.Colors exposing
     , red
     , redDark
     , redStatus
+    , toString
     , transparent
     , white
     , withAlpha
@@ -198,3 +199,14 @@ yellowStatus =
 yellowDark : Color
 yellowDark =
     hex "#FFCF3D"
+
+
+toString : Css.Color -> String
+toString color =
+    [ String.fromInt color.red
+    , String.fromInt color.green
+    , String.fromInt color.blue
+    , String.fromFloat color.alpha
+    ]
+        |> String.join ","
+        |> (\s -> "rgba(" ++ s ++ ")")

--- a/src/Nordea/Resources/Icons.elm
+++ b/src/Nordea/Resources/Icons.elm
@@ -1,6 +1,7 @@
 module Nordea.Resources.Icons exposing
     ( check
     , chevronDown
+    , chevronDownFilled
     , chevronUp
     , error
     , info
@@ -32,22 +33,8 @@ import Css.Global exposing (children, everything)
 import Html.Styled as Html exposing (Attribute, Html, div, styled)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Resources.Colors as Colors
-import Svg.Styled as Svg exposing (Svg, svg)
-import Svg.Styled.Attributes as SvgAttrs
-    exposing
-        ( clipRule
-        , cx
-        , cy
-        , d
-        , fill
-        , fillRule
-        , height
-        , r
-        , stroke
-        , strokeWidth
-        , viewBox
-        , width
-        )
+import Svg.Styled as Svg exposing (Svg, rect, svg)
+import Svg.Styled.Attributes as SvgAttrs exposing (clipRule, cx, cy, d, fill, fillRule, height, r, rx, stroke, strokeWidth, viewBox, width)
 
 
 
@@ -121,6 +108,22 @@ chevronDown attrs =
                 [ d "M4 7L10 13L16 7"
                 , stroke "currentColor"
                 , strokeWidth "2"
+                ]
+                []
+            ]
+        ]
+
+
+chevronDownFilled : List (Attribute msg) -> Html msg
+chevronDownFilled attrs =
+    iconContainer (css [ Css.width (rem 2) ] :: attrs)
+        [ svg [ viewBox "0 0 30 30", fill "none" ]
+            [ rect [ width "30", height "30", rx "2", fill "currentColor" ] []
+            , Svg.path
+                [ fillRule "evenodd"
+                , clipRule "evenodd"
+                , d "M20.5303 13.5304L14.9999 19.0607L9.46961 13.5304L10.5303 12.4697L14.9999 16.9391L19.4696 12.4697L20.5303 13.5304Z"
+                , fill (Colors.toString Colors.grayEclipse)
                 ]
                 []
             ]


### PR DESCRIPTION
Replace regular chevron down with a filled chevron. 

<img width="1372" alt="Screen Shot 2021-11-16 at 3 11 53 PM" src="https://user-images.githubusercontent.com/1861340/142000984-b4d7d442-0ca9-4c54-952d-498c67c12948.png">
