### PR TITLE
Design fixes with thea

### DIFF
--- a/src/Nordea/Components/Checkbox.elm
+++ b/src/Nordea/Components/Checkbox.elm
@@ -125,6 +125,7 @@ view attrs (Checkbox config) =
                     , borderColor Colors.grayMedium
                         |> styleIf (config.hasError && List.member config.appearance [ Standard, ListStyle ])
                     , position relative
+                    , boxSizing borderBox
 
                     -- Styling the checkmark
                     , after

--- a/src/Nordea/Components/Common.elm
+++ b/src/Nordea/Components/Common.elm
@@ -102,7 +102,15 @@ bottomInfo config =
         , charCounterView
         ]
         |> showIf (Maybe.isJust config.errorMessage)
-    , div [ css [ displayFlex, flexBasis (pct 100), justifyContent spaceBetween, marginTop (rem 0.5), Css.property "gap" "1rem" ] ]
+    , div
+        [ css
+            [ displayFlex
+            , flexBasis (pct 100)
+            , justifyContent spaceBetween
+            , marginTop (rem 0.2)
+            , Css.property "gap" "1rem"
+            ]
+        ]
         [ config.hintText
             |> Html.viewMaybe
                 (\hintText ->
@@ -135,7 +143,7 @@ topInfo config =
                 Custom string ->
                     string
     in
-    div [ css [ displayFlex, justifyContent spaceBetween, marginBottom (rem 0.5) ] ]
+    div [ css [ displayFlex, justifyContent spaceBetween, marginBottom (rem 0.2) ] ]
         [ bodyText [ css [ textStyle ] ] [ text config.labelText ]
         , config.requirednessHint
             |> Html.viewMaybe

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -16,11 +16,9 @@ import Css
         , backgroundColor
         , border3
         , borderBox
-        , borderColor
         , borderRadius
         , boxSizing
         , disabled
-        , em
         , focus
         , fontSize
         , height
@@ -142,10 +140,10 @@ getStyles config =
                 Colors.grayMedium
     in
     [ fontSize (rem 1)
-    , height (em 2.5)
-    , padding2 (em 0.75) (em 0.75)
-    , borderRadius (em 0.125)
-    , border3 (em 0.0625) solid borderColorStyle
+    , height (rem 2.5)
+    , padding2 (rem 0.75) (rem 0.75)
+    , borderRadius (rem 0.25)
+    , border3 (rem 0.0625) solid borderColorStyle
     , boxSizing borderBox
     , width (pct 100)
     , disabled [ backgroundColor Colors.grayWarm ]

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -9,7 +9,26 @@ module Nordea.Components.TextInput exposing
     , withPlaceholder
     )
 
-import Css exposing (Style, backgroundColor, border3, borderBox, borderColor, borderRadius, boxSizing, disabled, em, focus, fontSize, height, none, outline, padding2, pct, rem, solid, width)
+import Css
+    exposing
+        ( Style
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderRadius
+        , boxSizing
+        , disabled
+        , focus
+        , fontSize
+        , height
+        , none
+        , outline
+        , padding2
+        , pct
+        , rem
+        , solid
+        , width
+        )
 import Html.Styled exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (maxlength, pattern, placeholder, value)
 import Html.Styled.Events exposing (onInput)
@@ -111,10 +130,10 @@ getStyles config =
                 Colors.grayMedium
     in
     [ fontSize (rem 1)
-    , height (em 2.5)
-    , padding2 (em 0.75) (em 0.75)
-    , borderRadius (em 0.125)
-    , border3 (em 0.0625) solid borderColorStyle
+    , height (rem 2.5)
+    , padding2 (rem 0.75) (rem 0.75)
+    , borderRadius (rem 0.25)
+    , border3 (rem 0.0625) solid borderColorStyle
     , boxSizing borderBox
     , width (pct 100)
     , disabled [ backgroundColor Colors.grayWarm ]


### PR DESCRIPTION
Working with Thea today on some design tweaks 😊 

- Added border box to checkbox to senter check (see screenshot)
- Decreased spacing between label and input
- Use rem instead of em in text and number input
- Set same radius on input fields as dropdown 

<img width="176" alt="Screen Shot 2021-11-17 at 12 08 15 PM" src="https://user-images.githubusercontent.com/1861340/142191648-cd3bd11c-592c-432e-8ce4-8021b16b553a.png">

<img width="119" alt="Screen Shot 2021-11-17 at 12 08 21 PM" src="https://user-images.githubusercontent.com/1861340/142191641-ecebab9e-df3c-4886-807d-998b60f5ec63.png">
