### PR TITLE
Add new init function to allow disabled options without breaking backwards

### DIFF
--- a/explorer/src/Stories/Dropdown.elm
+++ b/explorer/src/Stories/Dropdown.elm
@@ -37,10 +37,10 @@ stories =
         [ ( "Standard"
           , \_ ->
                 Dropdown.init
-                    [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                    , optionInit { value = Rent, text = financingVariantToString Rent }
-                    , optionInit { value = Loan, text = financingVariantToString Loan }
-                    , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
@@ -50,10 +50,10 @@ stories =
         , ( "Standard with error"
           , \_ ->
                 Dropdown.init
-                    [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                    , optionInit { value = Rent, text = financingVariantToString Rent }
-                    , optionInit { value = Loan, text = financingVariantToString Loan }
-                    , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
@@ -64,10 +64,10 @@ stories =
         , ( "Simple"
           , \_ ->
                 Dropdown.simple
-                    [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                    , optionInit { value = Rent, text = financingVariantToString Rent }
-                    , optionInit { value = Loan, text = financingVariantToString Loan }
-                    , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
@@ -77,10 +77,10 @@ stories =
         , ( "Simple with error"
           , \_ ->
                 Dropdown.simple
-                    [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                    , optionInit { value = Rent, text = financingVariantToString Rent }
-                    , optionInit { value = Loan, text = financingVariantToString Loan }
-                    , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
@@ -91,10 +91,10 @@ stories =
         , ( "Disabled"
           , \_ ->
                 Dropdown.init
-                    [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                    , optionInit { value = Rent, text = financingVariantToString Rent }
-                    , optionInit { value = Loan, text = financingVariantToString Loan }
-                    , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
@@ -103,7 +103,7 @@ stories =
           )
         , ( "With disabled options"
           , \_ ->
-                Dropdown.init
+                Dropdown.initWithOptionProperties
                     [ optionInit { value = Leasing, text = financingVariantToString Leasing }
                     , optionInit { value = Rent, text = financingVariantToString Rent }
                         |> optionIsDisabled True

--- a/explorer/src/Stories/Label.elm
+++ b/explorer/src/Stories/Label.elm
@@ -74,10 +74,10 @@ stories =
                     [ Label.init "Choose financingVariant" Label.InputLabel
                         |> Label.view []
                             [ Dropdown.init
-                                [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                                , optionInit { value = Rent, text = financingVariantToString Rent }
-                                , optionInit { value = Loan, text = financingVariantToString Loan }
-                                , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                                [ { value = Leasing, text = financingVariantToString Leasing }
+                                , { value = Rent, text = financingVariantToString Rent }
+                                , { value = Loan, text = financingVariantToString Loan }
+                                , { value = HirePurchase, text = financingVariantToString HirePurchase }
                                 ]
                                 financingVariantToString
                                 (\_ -> NoOp)
@@ -87,10 +87,10 @@ stories =
                         |> Label.withErrorMessage (Just "Financing variant is required")
                         |> Label.view []
                             [ Dropdown.init
-                                [ optionInit { value = Leasing, text = financingVariantToString Leasing }
-                                , optionInit { value = Rent, text = financingVariantToString Rent }
-                                , optionInit { value = Loan, text = financingVariantToString Loan }
-                                , optionInit { value = HirePurchase, text = financingVariantToString HirePurchase }
+                                [ { value = Leasing, text = financingVariantToString Leasing }
+                                , { value = Rent, text = financingVariantToString Rent }
+                                , { value = Loan, text = financingVariantToString Loan }
+                                , { value = HirePurchase, text = financingVariantToString HirePurchase }
                                 ]
                                 financingVariantToString
                                 (\_ -> NoOp)

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -100,19 +100,7 @@ simple options optionToString onInput =
 
 init : List { value : a, text : String } -> (a -> String) -> (a -> msg) -> Dropdown a msg
 init options optionToString onInput =
-    let
-        optionsWithDisabled =
-            List.map (\option -> optionInit option) options
-    in
-    Dropdown
-        { placeholder = Nothing
-        , onInput = onInput
-        , options = optionsWithDisabled
-        , optionToString = optionToString
-        , selectedValue = Nothing
-        , hasError = False
-        , variant = Standard
-        }
+    initWithOptionProperties (List.map optionInit options) optionToString onInput
 
 
 initWithOptionProperties : List (Option a) -> (a -> String) -> (a -> msg) -> Dropdown a msg

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -1,4 +1,4 @@
-module Nordea.Components.Dropdown exposing (Dropdown, init, optionInit, optionIsDisabled, simple, view, withHasError, withSelectedValue)
+module Nordea.Components.Dropdown exposing (Dropdown, init, initWithOptionProperties, optionInit, optionIsDisabled, simple, view, withHasError, withSelectedValue)
 
 import Css
     exposing
@@ -89,7 +89,7 @@ type Dropdown a msg
     = Dropdown (DropdownProperties a msg)
 
 
-simple : List (Option a) -> (a -> String) -> (a -> msg) -> Dropdown a msg
+simple : List { value : a, text : String } -> (a -> String) -> (a -> msg) -> Dropdown a msg
 simple options optionToString onInput =
     let
         (Dropdown config) =
@@ -98,8 +98,25 @@ simple options optionToString onInput =
     Dropdown { config | variant = Simple }
 
 
-init : List (Option a) -> (a -> String) -> (a -> msg) -> Dropdown a msg
+init : List { value : a, text : String } -> (a -> String) -> (a -> msg) -> Dropdown a msg
 init options optionToString onInput =
+    let
+        optionsWithDisabled =
+            List.map (\option -> optionInit option) options
+    in
+    Dropdown
+        { placeholder = Nothing
+        , onInput = onInput
+        , options = optionsWithDisabled
+        , optionToString = optionToString
+        , selectedValue = Nothing
+        , hasError = False
+        , variant = Standard
+        }
+
+
+initWithOptionProperties : List (Option a) -> (a -> String) -> (a -> msg) -> Dropdown a msg
+initWithOptionProperties options optionToString onInput =
     Dropdown
         { placeholder = Nothing
         , onInput = onInput


### PR DESCRIPTION
Dropdown component can be initiated with only value and text using the init function as before. For Dropdown components with disabled options, initWithOptionsProperties can be used:)