### PR TITLE
Fix the use of :first-child css selector in UI Explorer

### DIFF
--- a/explorer/src/UIExplorer/Styled.elm
+++ b/explorer/src/UIExplorer/Styled.elm
@@ -1,6 +1,6 @@
 module UIExplorer.Styled exposing (StyledStories, StyledStory, styledStoriesOf)
 
-import Html.Styled exposing (Html, toUnstyled)
+import Html.Styled as Html exposing (Html, toUnstyled)
 import UIExplorer exposing (Model, UI, storiesOf)
 import UIExplorer.Unstyled exposing (Stories, Story)
 
@@ -25,4 +25,4 @@ toUnstyledStories stories =
 
 toUnstyledStory : StyledStory a b c -> Story a b c
 toUnstyledStory ( a, b, c ) =
-    ( a, \x -> toUnstyled (b x), c )
+    ( a, \x -> toUnstyled (Html.div [] [ b x ]), c )


### PR DESCRIPTION
The style tag from elm-css is added as the first child of the root component (from the Html.Styled package). When a component is the root and using the first-child css selector, the style tag from elm-css becomes the first child, which breaks the styling of the component.