### PR TITLE
Add-table-component: Added basic structure for table

### DIFF
--- a/explorer/src/Explorer.elm
+++ b/explorer/src/Explorer.elm
@@ -22,6 +22,7 @@ import Stories.RadioButton as RadioButton
 import Stories.Spinner as Spinner
 import Stories.Status as Status
 import Stories.StepIndicator as StepIndicator
+import Stories.Table as Table
 import Stories.Text as Header
 import Stories.TextInput as TextInput
 import Stories.Tooltip as Tooltip
@@ -76,6 +77,7 @@ main =
         , Header.stories
         , Status.stories
         , Modal.stories
+        , Table.stories
         , ProgressBar.stories
         , ProgressBarStepper.stories
         , Error.stories

--- a/explorer/src/Stories/Table.elm
+++ b/explorer/src/Stories/Table.elm
@@ -1,0 +1,58 @@
+module Stories.Table exposing (stories)
+
+import Html.Styled as Html
+import Nordea.Components.Table as Table
+import UIExplorer exposing (UI)
+import UIExplorer.Styled exposing (styledStoriesOf)
+
+
+stories : UI a b {}
+stories =
+    styledStoriesOf
+        "Table"
+        [ ( "Default"
+          , \_ ->
+                Table.view []
+                    [ Table.thead []
+                        [ Table.tr []
+                            [ Table.th [] [ Html.text "Referansenummer" ]
+                            , Table.th [] [ Html.text "Reg/serienummer" ]
+                            , Table.th [] [ Html.text "Kundenavn" ]
+                            , Table.th [] [ Html.text "Merke / Modell" ]
+                            , Table.th [] [ Html.text "Status" ]
+                            ]
+                        ]
+                    , Table.tbody []
+                        [ Table.tr []
+                            [ Table.td [] [ Html.text "1345937" ]
+                            , Table.td [] [ Html.text "AB3377" ]
+                            , Table.td [] [ Html.text "Davi Turbo AS" ]
+                            , Table.td [] [ Html.text "Best BMW'en" ]
+                            , Table.td [] [ Html.text "Innvilget" ]
+                            ]
+                        , Table.tr []
+                            [ Table.td [] [ Html.text "1345937" ]
+                            , Table.td [] [ Html.text "AB3377" ]
+                            , Table.td [] [ Html.text "Davi Turbo AS" ]
+                            , Table.td [] [ Html.text "Best BMW'en" ]
+                            , Table.td [] [ Html.text "Innvilget" ]
+                            ]
+                        , Table.tr []
+                            [ Table.td [] [ Html.text "1345937" ]
+                            , Table.td [] [ Html.text "AB3377" ]
+                            , Table.td [] [ Html.text "Davi Turbo AS" ]
+                            , Table.td [] [ Html.text "Best BMW'en" ]
+                            , Table.td [] [ Html.text "Innvilget" ]
+                            ]
+                        , Table.tr []
+                            [ Table.td [] [ Html.text "1345937" ]
+                            , Table.td [] [ Html.text "AB3377" ]
+                            , Table.td [] [ Html.text "Davi Turbo AS" ]
+                            , Table.td [] [ Html.text "Best BMW'en" ]
+                            , Table.td [] [ Html.text "Innvilget" ]
+                            ]
+                        ]
+                    ]
+          , {}
+          )
+        ]

--- a/explorer/src/Stories/Table.elm
+++ b/explorer/src/Stories/Table.elm
@@ -1,6 +1,19 @@
 module Stories.Table exposing (stories)
 
+import Css
+    exposing
+        ( center
+        , column
+        , displayFlex
+        , flex
+        , flexDirection
+        , int
+        , rem
+        , textAlign
+        , width
+        )
 import Html.Styled as Html
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Table as Table
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -12,44 +25,44 @@ stories =
         "Table"
         [ ( "Default"
           , \_ ->
-                Table.view []
+                Table.view [ css [ width (rem 60) ] ]
                     [ Table.thead []
                         [ Table.tr []
-                            [ Table.th [] [ Html.text "Referansenummer" ]
-                            , Table.th [] [ Html.text "Reg/serienummer" ]
-                            , Table.th [] [ Html.text "Kundenavn" ]
-                            , Table.th [] [ Html.text "Merke / Modell" ]
-                            , Table.th [] [ Html.text "Status" ]
+                            [ Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]
+                            , Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]
+                            , Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]
+                            , Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]
+                            , Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]
                             ]
                         ]
                     , Table.tbody []
                         [ Table.tr []
-                            [ Table.td [] [ Html.text "1345937" ]
-                            , Table.td [] [ Html.text "AB3377" ]
-                            , Table.td [] [ Html.text "Davi Turbo AS" ]
-                            , Table.td [] [ Html.text "Best BMW'en" ]
-                            , Table.td [] [ Html.text "Innvilget" ]
+                            [ Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
                             ]
                         , Table.tr []
-                            [ Table.td [] [ Html.text "1345937" ]
-                            , Table.td [] [ Html.text "AB3377" ]
-                            , Table.td [] [ Html.text "Davi Turbo AS" ]
-                            , Table.td [] [ Html.text "Best BMW'en" ]
-                            , Table.td [] [ Html.text "Innvilget" ]
+                            [ Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
                             ]
                         , Table.tr []
-                            [ Table.td [] [ Html.text "1345937" ]
-                            , Table.td [] [ Html.text "AB3377" ]
-                            , Table.td [] [ Html.text "Davi Turbo AS" ]
-                            , Table.td [] [ Html.text "Best BMW'en" ]
-                            , Table.td [] [ Html.text "Innvilget" ]
+                            [ Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
                             ]
                         , Table.tr []
-                            [ Table.td [] [ Html.text "1345937" ]
-                            , Table.td [] [ Html.text "AB3377" ]
-                            , Table.td [] [ Html.text "Davi Turbo AS" ]
-                            , Table.td [] [ Html.text "Best BMW'en" ]
-                            , Table.td [] [ Html.text "Innvilget" ]
+                            [ Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
+                            , Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]
                             ]
                         ]
                     ]

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -9,28 +9,34 @@ module Nordea.Components.Table exposing
 
 import Css
     exposing
-        ( backgroundColor
+        ( alignSelf
+        , backgroundColor
         , borderBottom3
+        , center
         , column
         , displayFlex
+        , ellipsis
         , flexDirection
+        , height
+        , hidden
         , hover
-        , left
+        , noWrap
         , nthChild
-        , paddingBottom
-        , paddingLeft
-        , paddingTop
-        , px
+        , overflow
+        , padding
+        , padding4
         , rem
         , row
         , solid
-        , textAlign
+        , textOverflow
+        , whiteSpace
         )
-import Css.Global exposing (descendants, typeSelector)
+import Css.Global as Css exposing (typeSelector)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Text as Text
 import Nordea.Resources.Colors as Colors
+import Nordea.Themes as Themes
 
 
 view : List (Attribute msg) -> List (Html msg) -> Html msg
@@ -46,7 +52,13 @@ view attrs children =
 -}
 thead : List (Attribute msg) -> List (Html msg) -> Html msg
 thead attrs children =
-    Html.thead (css [ borderBottom3 (px 1) solid Colors.grayLight ] :: attrs)
+    Html.thead
+        (css
+            [ height (rem 3.0)
+            , borderBottom3 (rem 0.0625) solid Colors.grayLight
+            ]
+            :: attrs
+        )
         children
 
 
@@ -58,7 +70,6 @@ tr attrs children =
         (css
             [ displayFlex
             , flexDirection row
-            , hover [ backgroundColor Colors.blueCloud |> Css.important ]
             ]
             :: attrs
         )
@@ -69,7 +80,9 @@ tr attrs children =
 -}
 th : List (Attribute msg) -> List (Html msg) -> Html msg
 th attrs children =
-    Html.th (css [ paddingLeft (rem 1) ] :: attrs) children
+    Html.th
+        (css [ padding4 (rem 1.0) (rem 0.75) (rem 0.75) (rem 0.75) ] :: attrs)
+        [ Text.textSmallHeavy |> Text.view [] children ]
 
 
 {-| Groups the body content in a table
@@ -80,11 +93,11 @@ tbody attrs children =
         (css
             [ displayFlex
             , flexDirection column
-            , descendants
+            , Css.children
                 [ typeSelector "tr"
-                    [ nthChild "even"
-                        [ backgroundColor Colors.grayLightBorder
-                        ]
+                    [ height (rem 4.5)
+                    , hover [ Themes.backgroundColor Themes.SecondaryColor Colors.blueCloud |> Css.important ]
+                    , nthChild "even" [ backgroundColor Colors.grayLightBorder ]
                     ]
                 ]
             ]
@@ -94,19 +107,18 @@ tbody attrs children =
 
 
 {-| Defines a cell in a table
+When only simple text inside the table cell, the text type here should be Text.BodyTextSmall
 -}
 td : List (Attribute msg) -> List (Html msg) -> Html msg
 td attrs children =
     Html.td
         (css
-            [ textAlign left
-            , paddingBottom (rem 1)
-            , paddingLeft (rem 1)
-            , paddingTop (rem 1)
+            [ padding (rem 0.75)
+            , alignSelf center
+            , textOverflow ellipsis
+            , whiteSpace noWrap
+            , overflow hidden
             ]
             :: attrs
         )
-        [ Text.init Text.BodyTextSmall
-            |> Text.view []
-                children
-        ]
+        children

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -1,0 +1,112 @@
+module Nordea.Components.Table exposing
+    ( tbody
+    , td
+    , th
+    , thead
+    , tr
+    , view
+    )
+
+import Css
+    exposing
+        ( backgroundColor
+        , borderBottom3
+        , column
+        , displayFlex
+        , flexDirection
+        , hover
+        , left
+        , nthChild
+        , paddingBottom
+        , paddingLeft
+        , paddingTop
+        , px
+        , rem
+        , row
+        , solid
+        , textAlign
+        )
+import Css.Global exposing (descendants, typeSelector)
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes exposing (css)
+import Nordea.Components.Text as Text
+import Nordea.Resources.Colors as Colors
+
+
+view : List (Attribute msg) -> List (Html msg) -> Html msg
+view attrs children =
+    Html.table
+        (css [ displayFlex, flexDirection column ]
+            :: attrs
+        )
+        children
+
+
+{-| Groups the header content in a table
+-}
+thead : List (Attribute msg) -> List (Html msg) -> Html msg
+thead attrs children =
+    Html.thead (css [ borderBottom3 (px 1) solid Colors.grayLight ] :: attrs)
+        children
+
+
+{-| Defines a row in a table
+-}
+tr : List (Attribute msg) -> List (Html msg) -> Html msg
+tr attrs children =
+    Html.tr
+        (css
+            [ displayFlex
+            , flexDirection row
+            , hover [ backgroundColor Colors.blueCloud |> Css.important ]
+            ]
+            :: attrs
+        )
+        children
+
+
+{-| Defines a header cell in a table
+-}
+th : List (Attribute msg) -> List (Html msg) -> Html msg
+th attrs children =
+    Html.th (css [ paddingLeft (rem 1) ] :: attrs) children
+
+
+{-| Groups the body content in a table
+-}
+tbody : List (Attribute msg) -> List (Html msg) -> Html msg
+tbody attrs children =
+    Html.tbody
+        (css
+            [ displayFlex
+            , flexDirection column
+            , descendants
+                [ typeSelector "tr"
+                    [ nthChild "even"
+                        [ backgroundColor Colors.grayLightBorder
+                        ]
+                    ]
+                ]
+            ]
+            :: attrs
+        )
+        children
+
+
+{-| Defines a cell in a table
+-}
+td : List (Attribute msg) -> List (Html msg) -> Html msg
+td attrs children =
+    Html.td
+        (css
+            [ textAlign left
+            , paddingBottom (rem 1)
+            , paddingLeft (rem 1)
+            , paddingTop (rem 1)
+            ]
+            :: attrs
+        )
+        [ Text.init Text.BodyTextSmall
+            |> Text.view []
+                children
+        ]

--- a/src/Nordea/Resources/Colors.elm
+++ b/src/Nordea/Resources/Colors.elm
@@ -14,6 +14,7 @@ module Nordea.Resources.Colors exposing
     , grayEclipse
     , grayHover
     , grayLight
+    , grayLightBorder
     , grayLightStatus
     , grayMedium
     , grayNordea
@@ -107,6 +108,11 @@ grayLight =
 grayLightStatus : Color
 grayLightStatus =
     hex "#D8D7D7"
+
+
+grayLightBorder : Color
+grayLightBorder =
+    hex "#E5E5EE33"
 
 
 grayCool : Color


### PR DESCRIPTION
- Adding a first edition of a table component of type A table (See screenshot)
- This first edition will miss a lot of the features that is displayed in the screenshot, but implements the basic building structures

![Screenshot 2021-12-01 at 15 16 31](https://user-images.githubusercontent.com/11747383/144250250-2cb2864b-73fb-4781-b5d3-68cc4ed7d177.png)

How it looks when showcased in the component library 👇
![Screenshot 2021-12-01 at 15 17 48](https://user-images.githubusercontent.com/11747383/144250559-92cedf00-5f05-4917-a511-49cb96e68d9b.png)
