### PR TITLE
Fix FlatLink button

### DIFF
--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -13,60 +13,7 @@ module Nordea.Components.Button exposing
     , withStyles
     )
 
-import Css
-    exposing
-        ( Style
-        , absolute
-        , alignItems
-        , auto
-        , backgroundColor
-        , batch
-        , border3
-        , borderBox
-        , borderRadius
-        , borderStyle
-        , boxShadow4
-        , boxSizing
-        , center
-        , column
-        , cursor
-        , disabled
-        , displayFlex
-        , flexDirection
-        , focus
-        , fontFamilies
-        , fontSize
-        , fontWeight
-        , height
-        , hover
-        , int
-        , left
-        , marginTop
-        , none
-        , num
-        , opacity
-        , outline
-        , padding
-        , padding2
-        , paddingRight
-        , pct
-        , pointer
-        , pointerEvents
-        , position
-        , relative
-        , rem
-        , right
-        , solid
-        , start
-        , textAlign
-        , textDecoration
-        , top
-        , transforms
-        , translateX
-        , translateY
-        , underline
-        , width
-        )
+import Css exposing (Style, absolute, alignItems, auto, backgroundColor, batch, border, border3, borderBox, borderRadius, borderStyle, boxShadow4, boxSizing, center, column, cursor, disabled, displayFlex, flexDirection, focus, fontFamilies, fontSize, fontWeight, height, hover, int, left, marginTop, none, num, opacity, outline, padding, padding2, paddingRight, pct, pointer, pointerEvents, position, relative, rem, right, solid, start, textAlign, textDecoration, top, transforms, translateX, translateY, transparent, underline, width)
 import Css.Global exposing (children, descendants, everything, withClass)
 import Css.Transitions exposing (easeOut, transition)
 import Html.Styled as Html exposing (Attribute, Html)
@@ -306,9 +253,11 @@ variantStyle variant =
             batch
                 [ textDecoration underline
                 , padding (rem 0)
+                , Themes.color Themes.PrimaryColor Colors.blueDeep
+                , border (rem 0)
+                , backgroundColor transparent
                 , hover
-                    [ Themes.color Themes.PrimaryColorLight Colors.blueNordea
-                    ]
+                    [ Themes.color Themes.PrimaryColorLight Colors.blueNordea ]
                 , focus
                     [ outline none ]
                 ]

--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -13,7 +13,62 @@ module Nordea.Components.Button exposing
     , withStyles
     )
 
-import Css exposing (Style, absolute, alignItems, auto, backgroundColor, batch, border, border3, borderBox, borderRadius, borderStyle, boxShadow4, boxSizing, center, column, cursor, disabled, displayFlex, flexDirection, focus, fontFamilies, fontSize, fontWeight, height, hover, int, left, marginTop, none, num, opacity, outline, padding, padding2, paddingRight, pct, pointer, pointerEvents, position, relative, rem, right, solid, start, textAlign, textDecoration, top, transforms, translateX, translateY, transparent, underline, width)
+import Css
+    exposing
+        ( Style
+        , absolute
+        , alignItems
+        , auto
+        , backgroundColor
+        , batch
+        , border
+        , border3
+        , borderBox
+        , borderRadius
+        , borderStyle
+        , boxShadow4
+        , boxSizing
+        , center
+        , column
+        , cursor
+        , disabled
+        , displayFlex
+        , flexDirection
+        , focus
+        , fontFamilies
+        , fontSize
+        , fontWeight
+        , height
+        , hover
+        , int
+        , left
+        , marginTop
+        , none
+        , num
+        , opacity
+        , outline
+        , padding
+        , padding2
+        , paddingRight
+        , pct
+        , pointer
+        , pointerEvents
+        , position
+        , relative
+        , rem
+        , right
+        , solid
+        , start
+        , textAlign
+        , textDecoration
+        , top
+        , transforms
+        , translateX
+        , translateY
+        , transparent
+        , underline
+        , width
+        )
 import Css.Global exposing (children, descendants, everything, withClass)
 import Css.Transitions exposing (easeOut, transition)
 import Html.Styled as Html exposing (Attribute, Html)

--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -307,6 +307,7 @@ variantStyle variant =
         FlatLinkStyle ->
             batch
                 [ textDecoration underline
+                , fontSize (rem 0.875)
                 , padding (rem 0)
                 , Themes.color Themes.PrimaryColor Colors.blueDeep
                 , border (rem 0)


### PR DESCRIPTION
Somehow the flatlink button had a border and background when used with other applications, but Storybook Explorer didnt show it. 

![image](https://user-images.githubusercontent.com/14363025/146331250-8b2de201-d81c-4cae-a163-1ca6a31a362f.png)
