### PR TITLE
Add script to symlink fonts for dev environment

### DIFF
--- a/explorer/README.md
+++ b/explorer/README.md
@@ -1,0 +1,3 @@
+# Explorer
+
+Run `yarn link-fonts` (only supported on macOS and Linux) when setting up the project for the first time.

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -2,7 +2,8 @@
   "name": "explorer",
   "scripts": {
     "start": "elm-live src/Explorer.elm --open --dir=public --start-page=index.html -- --output=public/explorer.js --debug",
-    "build": "elm make src/Explorer.elm --output=public/explorer.js && shx cp -r ../static/fonts ./public"
+    "build": "elm make src/Explorer.elm --output=public/explorer.js && shx cp -r ../static/fonts ./public",
+    "link-fonts": "ln -s ../../static/fonts ./public/fonts"
   },
   "devDependencies": {
     "elm": "^0.19.1-5",


### PR DESCRIPTION
Netlify does not support symlinks, and therefore we have to copy fonts to `public` at build time. This PR adds a Yarn script that creates a symlink to the `fonts` directory that can be used in a development environment.