### PR TITLE
Move number input to the right

### DIFF
--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -27,7 +27,9 @@ import Css
         , padding2
         , pct
         , rem
+        , right
         , solid
+        , textAlign
         , width
         )
 import Html.Styled exposing (Attribute, Html, input, styled)
@@ -141,6 +143,7 @@ getStyles config =
     in
     [ fontSize (rem 1)
     , height (rem 3)
+    , textAlign right
     , padding2 (rem 0.75) (rem 0.75)
     , borderRadius (rem 0.25)
     , border3 (rem 0.0625) solid borderColorStyle

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -19,10 +19,10 @@ import Css
         , borderRadius
         , boxSizing
         , disabled
+        , display
         , focus
         , fontSize
         , height
-        , margin
         , none
         , outline
         , padding2
@@ -147,8 +147,8 @@ getStyles config =
     in
     [ fontSize (rem 1)
     , height (rem 3)
-    , pseudoElement "-webkit-outer-spin-button" [ property "-webkit-appearance" "none", margin (px 0) ]
-    , pseudoElement "-webkit-inner-spin-button" [ property "-webkit-appearance" "none", margin (px 0) ]
+    , pseudoElement "-webkit-outer-spin-button" [ display none ]
+    , pseudoElement "-webkit-inner-spin-button" [ display none ]
     , property "-moz-appearance" "textfield"
     , textAlign right
     , padding2 (rem 0.75) (rem 0.75)

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -22,10 +22,14 @@ import Css
         , focus
         , fontSize
         , height
+        , margin
         , none
         , outline
         , padding2
         , pct
+        , property
+        , pseudoElement
+        , px
         , rem
         , right
         , solid
@@ -143,6 +147,9 @@ getStyles config =
     in
     [ fontSize (rem 1)
     , height (rem 3)
+    , pseudoElement "-webkit-outer-spin-button" [ property "-webkit-appearance" "none", margin (px 0) ]
+    , pseudoElement "-webkit-inner-spin-button" [ property "-webkit-appearance" "none", margin (px 0) ]
+    , property "-moz-appearance" "textfield"
     , textAlign right
     , padding2 (rem 0.75) (rem 0.75)
     , borderRadius (rem 0.25)


### PR DESCRIPTION
In this PR we are moving the input of the number input to the right. 
We are also removing the default arrow icon which increases and decreases the input number, because it was colliding with the right input.

![image](https://user-images.githubusercontent.com/9946018/148395418-92691ece-d5c1-4ff2-a83c-7d6bbf3a6f0e.png)
