### PR TITLE
Fix styling for dropdown filter

### DIFF
--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -78,12 +78,7 @@ update msg config =
         OnClickClearSearchComponentInput ->
             let
                 emptySearchString =
-                    case config.searchComponentInput of
-                        Just string ->
-                            Just ""
-
-                        Nothing ->
-                            Nothing
+                    config.searchComponentInput |> Maybe.map (\_ -> "")
             in
             { config | searchComponentInput = emptySearchString }
 

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -18,7 +18,7 @@ type alias Config =
     , searchComponentInput : Maybe String
     , searchHasFocus : Bool
     , isFeatureBoxOpen : Bool
-        , isProgressBarCompleted : Bool
+    , isProgressBarCompleted : Bool
     }
 
 
@@ -77,14 +77,14 @@ update msg config =
 
         OnClickClearSearchComponentInput ->
             let
-                emptySearchString = case config.searchComponentInput of
-                    Just string ->
-                        Just ""
+                emptySearchString =
+                    case config.searchComponentInput of
+                        Just string ->
+                            Just ""
 
-                    Nothing ->
-                        Nothing
+                        Nothing ->
+                            Nothing
             in
-
             { config | searchComponentInput = emptySearchString }
 
         NoOp ->

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -27,7 +27,7 @@ type Msg
     | SearchComponentInput String
     | SearchComponentSelected (Item FinancingVariant)
     | SearchComponentFocus Bool
-    | OnCross
+    | OnClickClearSearchComponentInput
     | NoOp
     | ToggleModal
     | ToggleFeatureBox
@@ -75,7 +75,7 @@ update msg config =
         SearchComponentFocus value ->
             { config | searchHasFocus = value }
 
-        OnCross ->
+        OnClickClearSearchComponentInput ->
             let
                 emptySearchString = case config.searchComponentInput of
                     Just string ->

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -27,6 +27,7 @@ type Msg
     | SearchComponentInput String
     | SearchComponentSelected (Item FinancingVariant)
     | SearchComponentFocus Bool
+    | OnCross
     | NoOp
     | ToggleModal
     | ToggleFeatureBox
@@ -73,6 +74,18 @@ update msg config =
 
         SearchComponentFocus value ->
             { config | searchHasFocus = value }
+
+        OnCross ->
+            let
+                emptySearchString = case config.searchComponentInput of
+                    Just string ->
+                        Just ""
+
+                    Nothing ->
+                        Nothing
+            in
+
+            { config | searchComponentInput = emptySearchString }
 
         NoOp ->
             config

--- a/explorer/src/Stories/DropdownFilter.elm
+++ b/explorer/src/Stories/DropdownFilter.elm
@@ -1,12 +1,13 @@
 module Stories.DropdownFilter exposing (stories)
 
 import Config exposing (Config, FinancingVariant(..), Msg(..))
+import Css
 import Html.Styled as Html
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.DropdownFilter as DropdownFilter
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
-import Css
-import Html.Styled.Attributes exposing (css)
+
 
 financingVariantToString : FinancingVariant -> String
 financingVariantToString financingVariant =
@@ -34,7 +35,6 @@ stories =
                     , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     , { value = HirePurchase, text = financingVariantToString HirePurchase }
                     , { value = HirePurchase, text = financingVariantToString HirePurchase }
-
                     ]
               }
             , { header = "Oor this"
@@ -107,5 +107,4 @@ stories =
                 Html.text "TODO debouncer and RemoteData"
           , {}
           )
-
         ]

--- a/explorer/src/Stories/DropdownFilter.elm
+++ b/explorer/src/Stories/DropdownFilter.elm
@@ -5,7 +5,8 @@ import Html.Styled as Html
 import Nordea.Components.DropdownFilter as DropdownFilter
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
-
+import Css
+import Html.Styled.Attributes exposing (css)
 
 financingVariantToString : FinancingVariant -> String
 financingVariantToString financingVariant =
@@ -31,11 +32,16 @@ stories =
               , items =
                     [ { value = Loan, text = financingVariantToString Loan }
                     , { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
+
                     ]
               }
             , { header = "Oor this"
               , items =
                     [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Rent, text = financingVariantToString Rent }
                     , { value = Rent, text = financingVariantToString Rent }
                     ]
               }
@@ -52,6 +58,7 @@ stories =
                             SearchComponentSelected
                             searchResult
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            OnCross
                 in
                 DropdownFilter.view
                     defaultOptions
@@ -70,6 +77,7 @@ stories =
                             SearchComponentSelected
                             removedGroups
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            OnCross
                             |> DropdownFilter.withFocusState True
                 in
                 DropdownFilter.view
@@ -86,6 +94,7 @@ stories =
                             SearchComponentSelected
                             searchResult
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            OnCross
                             |> DropdownFilter.withFocusHandling "explorer" model.customModel.searchHasFocus SearchComponentFocus
                 in
                 DropdownFilter.view
@@ -98,4 +107,5 @@ stories =
                 Html.text "TODO debouncer and RemoteData"
           , {}
           )
+        
         ]

--- a/explorer/src/Stories/DropdownFilter.elm
+++ b/explorer/src/Stories/DropdownFilter.elm
@@ -58,7 +58,7 @@ stories =
                             SearchComponentSelected
                             searchResult
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
-                            OnCross
+                            OnClickClearSearchComponentInput
                 in
                 DropdownFilter.view
                     defaultOptions
@@ -77,7 +77,7 @@ stories =
                             SearchComponentSelected
                             removedGroups
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
-                            OnCross
+                            OnClickClearSearchComponentInput
                             |> DropdownFilter.withFocusState True
                 in
                 DropdownFilter.view
@@ -94,7 +94,7 @@ stories =
                             SearchComponentSelected
                             searchResult
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
-                            OnCross
+                            OnClickClearSearchComponentInput
                             |> DropdownFilter.withFocusHandling "explorer" model.customModel.searchHasFocus SearchComponentFocus
                 in
                 DropdownFilter.view
@@ -107,5 +107,5 @@ stories =
                 Html.text "TODO debouncer and RemoteData"
           , {}
           )
-        
+
         ]

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -37,6 +37,7 @@ type alias DropdownFilterProperties a msg =
     { searchItems : List (ItemGroup a)
     , onInput : String -> msg
     , onSelectedValue : Item a -> msg
+    , onCross : msg
     , rawInputString : String
     , filterValues : String -> String -> Bool
     , onFocus : Maybe ( String, Bool -> msg )
@@ -55,12 +56,13 @@ type DropdownFilter a msg
   - TODO handle isSearching - use with RemoteData to show that new data is loading
 
 -}
-init : (String -> msg) -> (Item a -> msg) -> List (ItemGroup a) -> String -> DropdownFilter a msg
-init onSearchHandler onSelectedValue searchItems rawInputString =
+init : (String -> msg) -> (Item a -> msg) -> List (ItemGroup a) -> String -> msg -> DropdownFilter a msg
+init onSearchHandler onSelectedValue searchItems rawInputString onCross =
     DropdownFilter
         { searchItems = searchItems
         , onInput = onSearchHandler
         , onSelectedValue = onSelectedValue
+        , onCross = onCross
         , filterValues = \searchString -> \value -> String.contains (String.toLower searchString) (String.toLower value)
         , rawInputString = rawInputString
         , onFocus = Nothing
@@ -68,6 +70,7 @@ init onSearchHandler onSelectedValue searchItems rawInputString =
         , hasError = False
         , isLoading = False
         }
+
 
 
 view : DropdownFilter a msg -> List (Html.Attribute msg) -> Html msg
@@ -115,7 +118,7 @@ view (DropdownFilter options) attributes =
          ]
             ++ attributes
         )
-        [ inputSearchView options.hasFocus options.rawInputString options.onInput options.onFocus
+        [ inputSearchView options.hasFocus options.rawInputString options.onInput options.onFocus options.onCross
         , if options.isLoading then
             Spinner.small []
 
@@ -155,8 +158,8 @@ view (DropdownFilter options) attributes =
         ]
 
 
-inputSearchView : Bool -> String -> (String -> msg) -> Maybe ( String, Bool -> msg ) -> Html msg
-inputSearchView hasFocus searchString onInput onFocus =
+inputSearchView : Bool -> String -> (String -> msg) -> Maybe ( String, Bool -> msg ) -> msg -> Html msg
+inputSearchView hasFocus searchString onInput onFocus onCross =
     Html.div
         [ Attr.css
             [ Css.position Css.relative
@@ -180,6 +183,7 @@ inputSearchView hasFocus searchString onInput onFocus =
                 , Css.borderRadius4 (Css.px 4) (Css.px 4) (Css.px 0) (Css.px 0)
                 , Css.boxShadow5 Css.inset (Css.px 0) (Css.px -1) (Css.px 0) Colors.grayLight
                 , Css.height (Css.px 48)
+                , Css.paddingRight (Css.rem 2)
                 --, Css.fontSize (Css.rem 1.0)
                 --, Css.lineHeight (Css.rem 1.4)
                 ]
@@ -202,7 +206,7 @@ inputSearchView hasFocus searchString onInput onFocus =
                 ]
           in
           if String.length searchString > 0 then
-              Icon.cross attributes
+              Icon.cross (attributes ++ [Events.onClick onCross])
           else
             if hasFocus then
               Icon.chevronUp attributes

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -127,6 +127,8 @@ view (DropdownFilter options) attributes =
                 [ Attr.css
                     [ Css.listStyle Css.none
                     , Css.padding3 (Css.px 3) (Css.px 1) (Css.px 12)
+                    , Css.maxHeight (Css.rem 16.75)
+                    , Css.overflowY Css.auto
                     ]
                 ]
                 (List.concatMap

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -37,7 +37,7 @@ type alias DropdownFilterProperties a msg =
     { searchItems : List (ItemGroup a)
     , onInput : String -> msg
     , onSelectedValue : Item a -> msg
-    , onCross : msg
+    , onClickClearInput : msg
     , rawInputString : String
     , filterValues : String -> String -> Bool
     , onFocus : Maybe ( String, Bool -> msg )
@@ -57,12 +57,12 @@ type DropdownFilter a msg
 
 -}
 init : (String -> msg) -> (Item a -> msg) -> List (ItemGroup a) -> String -> msg -> DropdownFilter a msg
-init onSearchHandler onSelectedValue searchItems rawInputString onCross =
+init onSearchHandler onSelectedValue searchItems rawInputString onClickClearInput =
     DropdownFilter
         { searchItems = searchItems
         , onInput = onSearchHandler
         , onSelectedValue = onSelectedValue
-        , onCross = onCross
+        , onClickClearInput = onClickClearInput
         , filterValues = \searchString -> \value -> String.contains (String.toLower searchString) (String.toLower value)
         , rawInputString = rawInputString
         , onFocus = Nothing
@@ -118,7 +118,7 @@ view (DropdownFilter options) attributes =
          ]
             ++ attributes
         )
-        [ inputSearchView options.hasFocus options.rawInputString options.onInput options.onFocus options.onCross
+        [ inputSearchView options.hasFocus options.rawInputString options.onInput options.onFocus options.onClickClearInput
         , if options.isLoading then
             Spinner.small []
 
@@ -159,7 +159,7 @@ view (DropdownFilter options) attributes =
 
 
 inputSearchView : Bool -> String -> (String -> msg) -> Maybe ( String, Bool -> msg ) -> msg -> Html msg
-inputSearchView hasFocus searchString onInput onFocus onCross =
+inputSearchView hasFocus searchString onInput onFocus onClickClearInput =
     Html.div
         [ Attr.css
             [ Css.position Css.relative
@@ -206,7 +206,7 @@ inputSearchView hasFocus searchString onInput onFocus onCross =
                 ]
           in
           if String.length searchString > 0 then
-              Icon.cross (attributes ++ [Events.onClick onCross])
+              Icon.cross (attributes ++ [Events.onClick onClickClearInput])
           else
             if hasFocus then
               Icon.chevronUp attributes

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -196,16 +196,19 @@ inputSearchView hasFocus searchString onInput onFocus =
                     , Css.right (Css.rem 0.75)
                     , Css.width (Css.rem 1.125) |> Css.important
                     , Css.height (Css.rem 1.125)
-                    , Css.pointerEvents Css.none
+                    , Css.cursor Css.pointer
                     , Css.color Css.inherit
                     ]
                 ]
           in
-          if hasFocus then
-            Icon.chevronUp attributes
-
+          if String.length searchString > 0 then
+              Icon.cross attributes
           else
-            Icon.chevronDown attributes
+            if hasFocus then
+              Icon.chevronUp attributes
+
+            else
+              Icon.chevronDown attributes
         ]
 
 

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -72,7 +72,6 @@ init onSearchHandler onSelectedValue searchItems rawInputString onClickClearInpu
         }
 
 
-
 view : DropdownFilter a msg -> List (Html.Attribute msg) -> Html msg
 view (DropdownFilter options) attributes =
     let
@@ -184,6 +183,7 @@ inputSearchView hasFocus searchString onInput onFocus onClickClearInput =
                 , Css.boxShadow5 Css.inset (Css.px 0) (Css.px -1) (Css.px 0) Colors.grayLight
                 , Css.height (Css.px 48)
                 , Css.paddingRight (Css.rem 2)
+
                 --, Css.fontSize (Css.rem 1.0)
                 --, Css.lineHeight (Css.rem 1.4)
                 ]
@@ -206,13 +206,13 @@ inputSearchView hasFocus searchString onInput onFocus onClickClearInput =
                 ]
           in
           if String.length searchString > 0 then
-              Icon.cross (attributes ++ [Events.onClick onClickClearInput])
-          else
-            if hasFocus then
-              Icon.chevronUp attributes
+            Icon.cross (attributes ++ [ Events.onClick onClickClearInput ])
 
-            else
-              Icon.chevronDown attributes
+          else if hasFocus then
+            Icon.chevronUp attributes
+
+          else
+            Icon.chevronDown attributes
         ]
 
 


### PR DESCRIPTION
- Add cross to dropdown filter, which deletes search string when clicked
- Add scroll to the list of elements for the search, rather than the search box and the list of results. This must also be fixed in leasing.
- Add cursor pointer to the icon in the search box
- Add padding to input field so it is not possible to write search string over the icon in the search box

Now:
![image](https://user-images.githubusercontent.com/9946018/148531714-5df694ea-2baa-4295-8595-f821aa10912a.png)

With scroll now:
![image](https://user-images.githubusercontent.com/9946018/148532172-da422495-ee72-4614-a4ad-559f32706640.png)


Previous:
![image](https://user-images.githubusercontent.com/9946018/148531811-f552330b-05e1-442d-bfc4-6e482a67b2e4.png)
