### PR TITLE
Remove default border and padding from RadioGroup

### DIFF
--- a/src/Nordea/Components/RadioGroup.elm
+++ b/src/Nordea/Components/RadioGroup.elm
@@ -26,7 +26,7 @@ init label =
 
 view : List (Attribute msg) -> List (Html msg) -> RadioGroup -> Html msg
 view attrs contents (RadioGroup properties) =
-    Html.fieldset attrs
+    Html.fieldset [ css [ Css.borderStyle Css.none, Css.padding (rem 0) ] ]
         ([ Html.legend [ css [ marginBottom (rem 0.5) ] ] [ Html.text properties.label ]
          , Html.div [ css [ displayFlex, flexWrap wrap, flexDirection row, Css.property "gap" "1rem" ] ] contents
          ]


### PR DESCRIPTION
Before:
![image (9)](https://user-images.githubusercontent.com/1861340/149746781-5997d9b8-3d8c-4c5b-9665-eda479129de7.png)


After:
![image](https://user-images.githubusercontent.com/1861340/149746449-f5cd4822-2f0e-4727-a653-0d8835a5aa6e.png)
