### PR TITLE
Add spinner with custom width

### DIFF
--- a/explorer/src/Stories/Spinner.elm
+++ b/explorer/src/Stories/Spinner.elm
@@ -1,6 +1,8 @@
 module Stories.Spinner exposing (..)
 
 import Config exposing (Config, Msg(..))
+import Css exposing (rem, width)
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Spinner as Spinner
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -12,6 +14,10 @@ stories =
         "Spinner"
         [ ( "Small"
           , \_ -> Spinner.small []
+          , {}
+          )
+        , ( "Custom"
+          , \_ -> Spinner.custom [ css [ width (rem 1) ] ]
           , {}
           )
         ]

--- a/src/Nordea/Components/Spinner.elm
+++ b/src/Nordea/Components/Spinner.elm
@@ -1,4 +1,4 @@
-module Nordea.Components.Spinner exposing (small)
+module Nordea.Components.Spinner exposing (custom, small)
 
 import Css exposing (Style, color, height, rem, width)
 import Html.Styled exposing (Attribute, Html, div)
@@ -11,3 +11,8 @@ import Nordea.Themes as Themes
 small : List (Attribute msg) -> Html msg
 small attrs =
     Icons.spinner (css [ width (rem 3.75), Themes.color Themes.PrimaryColor Colors.blueDeep ] :: attrs)
+
+
+custom : List (Attribute msg) -> Html msg
+custom attrs =
+    Icons.spinner (css [ Themes.color Themes.PrimaryColor Colors.blueDeep ] :: attrs)


### PR DESCRIPTION
Added an alternative to Spinner component without defined standard width. This way we can use it places like inside buttons etc with custom widths without having to use `Css.important` to overwrite.

![image](https://user-images.githubusercontent.com/14363025/150089292-59e49d8a-5c6a-4fa9-aaf7-20965c3dff62.png)