### PR TITLE
[NB: Breaking changes] Allow english text translations

### DIFF
--- a/explorer/src/Stories/Error.elm
+++ b/explorer/src/Stories/Error.elm
@@ -16,14 +16,7 @@ stories =
         "Error"
         [ ( "Internal server error"
           , \_ ->
-                Error.internalServerError .no
-                    |> Error.view [] []
-          , {}
-          )
-        , ( "Internal server error (custom email)"
-          , \_ ->
-                Error.internalServerError .no
-                    |> Error.withCustomSupportEmail "jonas.ueland@nordea.com"
+                Error.internalServerError .no "contact.us@nordea.com"
                     |> Error.view [] []
           , {}
           )

--- a/src/Nordea/Components/Common.elm
+++ b/src/Nordea/Components/Common.elm
@@ -29,8 +29,8 @@ import Nordea.Resources.Icons as Icons
 
 
 type RequirednessHint
-    = Mandatory ({ no : String, se : String, dk : String } -> String)
-    | Optional ({ no : String, se : String, dk : String } -> String)
+    = Mandatory ({ no : String, se : String, dk : String, en : String } -> String)
+    | Optional ({ no : String, se : String, dk : String, en : String } -> String)
     | Custom String
 
 
@@ -143,13 +143,15 @@ topInfo config =
 
 strings =
     { mandatory =
-        { no = "Obligatorisk"
-        , se = "Obligatoriskt"
-        , dk = "Obligatorisk"
+        { no = "Påkrevd"
+        , se = "Krävs"
+        , dk = "Påkrævet"
+        , en = "Required"
         }
     , optional =
         { no = "Valgfritt"
         , se = "Valfritt"
         , dk = "Valgfrit"
+        , en = "Optional"
         }
     }

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -189,14 +189,12 @@ inputSearchView hasError hasFocus searchString onInput onFocus onClickClearInput
                     ]
                 , if hasFocus then
                     Css.borderRadius4 (Css.px 4) (Css.px 4) (Css.px 0) (Css.px 0)
+
                   else
                     Css.borderRadius4 (Css.px 4) (Css.px 4) (Css.px 4) (Css.px 4)
                 , Css.boxShadow5 Css.inset (Css.px 0) (Css.px -1) (Css.px 0) Colors.grayLight
                 , Css.height (Css.px 48)
                 , Css.paddingRight (Css.rem 2)
-
-                --, Css.fontSize (Css.rem 1.0)
-                --, Css.lineHeight (Css.rem 1.4)
                 ]
              ]
                 ++ onFocusAttrs onFocus

--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -54,8 +54,8 @@ type LabelType
 
 
 type RequirednessHint
-    = Mandatory ({ no : String, se : String, dk : String } -> String)
-    | Optional ({ no : String, se : String, dk : String } -> String)
+    = Mandatory ({ no : String, se : String, dk : String, en : String } -> String)
+    | Optional ({ no : String, se : String, dk : String, en : String } -> String)
     | Custom String
 
 

--- a/src/Nordea/Components/ProgressBarStepper.elm
+++ b/src/Nordea/Components/ProgressBarStepper.elm
@@ -25,7 +25,7 @@ import Nordea.Resources.Colors as Colors
 type alias ViewConfig =
     { steps : List String
     , currentStep : Int
-    , nextLabel : { no : String, se : String, dk : String } -> String
+    , nextLabel : { no : String, se : String, dk : String, en : String } -> String
     }
 
 
@@ -80,5 +80,6 @@ strings =
         { no = "Neste: "
         , se = "Nästa: "
         , dk = "Næste: "
+        , en = "Next"
         }
     }

--- a/src/Nordea/Components/ProgressBarStepper.elm
+++ b/src/Nordea/Components/ProgressBarStepper.elm
@@ -80,6 +80,6 @@ strings =
         { no = "Neste: "
         , se = "Nästa: "
         , dk = "Næste: "
-        , en = "Next"
+        , en = "Next: "
         }
     }


### PR DESCRIPTION
- In all translations there is added an english text translation
- The Error pages now have to send in their support email by default. This is because it does not make sense to relate email to language (country, yes, language, no), and also, it is very likely that we have different customer support emails for different systems 😊 