### PR TITLE
Add width to GroupLabel style

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -11,7 +11,24 @@ module Nordea.Components.Label exposing
     , withShowFocusOutline
     )
 
-import Css exposing (Style, border, column, displayFlex, flexBasis, flexDirection, flexWrap, marginInlineEnd, marginInlineStart, padding, pct, pseudoClass, rem, width, wrap)
+import Css
+    exposing
+        ( Style
+        , border
+        , column
+        , displayFlex
+        , flexBasis
+        , flexDirection
+        , flexWrap
+        , marginInlineEnd
+        , marginInlineStart
+        , padding
+        , pct
+        , pseudoClass
+        , rem
+        , width
+        , wrap
+        )
 import Css.Global exposing (descendants, everything, typeSelector)
 import Html.Styled
     exposing

--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -138,7 +138,7 @@ view attrs children (Label config) =
                 ]
                 attrs
                 ((legend
-                    [ css [ width (pct 100), padding (rem 0), flexBasis (pct 100), Css.Global.children [ everything [ flexBasis (pct 100) ] ] ] ]
+                    [ css [ width (pct 100), padding (rem 0), Css.Global.children [ everything [ flexBasis (pct 100) ] ] ] ]
                     [ topInfo commonConfig ]
                     |> showIf (not (String.isEmpty config.labelText) || Maybe.isJust config.requirednessHint)
                  )

--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -11,23 +11,7 @@ module Nordea.Components.Label exposing
     , withShowFocusOutline
     )
 
-import Css
-    exposing
-        ( Style
-        , border
-        , column
-        , displayFlex
-        , flexBasis
-        , flexDirection
-        , flexWrap
-        , marginInlineEnd
-        , marginInlineStart
-        , padding
-        , pct
-        , pseudoClass
-        , rem
-        , wrap
-        )
+import Css exposing (Style, border, column, displayFlex, flexBasis, flexDirection, flexWrap, marginInlineEnd, marginInlineStart, padding, pct, pseudoClass, rem, width, wrap)
 import Css.Global exposing (descendants, everything, typeSelector)
 import Html.Styled
     exposing
@@ -137,7 +121,7 @@ view attrs children (Label config) =
                 ]
                 attrs
                 ((legend
-                    [ css [ padding (rem 0), flexBasis (pct 100), Css.Global.children [ everything [ flexBasis (pct 100) ] ] ] ]
+                    [ css [ width (pct 100), padding (rem 0), flexBasis (pct 100), Css.Global.children [ everything [ flexBasis (pct 100) ] ] ] ]
                     [ topInfo commonConfig ]
                     |> showIf (not (String.isEmpty config.labelText) || Maybe.isJust config.requirednessHint)
                  )


### PR DESCRIPTION
Useful when we use the `Label.withRequirednessHint`. With (pct 100) it pushes the hint to the end.

Example:
![image](https://user-images.githubusercontent.com/14363025/154024533-3955a8e6-065c-4ff0-8b27-40b6c63399c5.png)
