### PR TITLE
Disable grammarly browser extension

### DIFF
--- a/src/Nordea/Components/TextArea.elm
+++ b/src/Nordea/Components/TextArea.elm
@@ -30,7 +30,7 @@ import Css
         , solid
         )
 import Html.Styled exposing (Attribute, Html, styled, textarea)
-import Html.Styled.Attributes exposing (maxlength, placeholder, value)
+import Html.Styled.Attributes as Attrs exposing (maxlength, placeholder, value)
 import Html.Styled.Events exposing (onBlur, onInput)
 import Maybe.Extra as Maybe
 import Nordea.Resources.Colors as Colors
@@ -113,6 +113,9 @@ getAttributes config =
         , config.placeholder |> Maybe.map placeholder
         , config.onBlur |> Maybe.map onBlur
         , config.maxLength |> Maybe.map maxlength
+        , Just (Attrs.attribute "data-gramm" "false")
+        , Just (Attrs.attribute "data-gramm_editor" "false")
+        , Just (Attrs.attribute "data-enable-grammarly" "false")
         ]
 
 

--- a/src/Nordea/Components/TextArea.elm
+++ b/src/Nordea/Components/TextArea.elm
@@ -113,6 +113,8 @@ getAttributes config =
         , config.placeholder |> Maybe.map placeholder
         , config.onBlur |> Maybe.map onBlur
         , config.maxLength |> Maybe.map maxlength
+
+        -- Disable the Grammarly browser extension to avoid crashing Elm.
         , Just (Attrs.attribute "data-gramm" "false")
         , Just (Attrs.attribute "data-gramm_editor" "false")
         , Just (Attrs.attribute "data-enable-grammarly" "false")


### PR DESCRIPTION
The Grammarly browser extension modifies the DOM, which crashes Elm. This PR disables the extension.