### PR TITLE
#144 - Small Textinput

### DIFF
--- a/explorer/src/Stories/TextInput.elm
+++ b/explorer/src/Stories/TextInput.elm
@@ -65,4 +65,11 @@ stories =
                     |> TextInput.view []
           , {}
           )
+        , ( "Small size"
+          , \_ ->
+                TextInput.init "Text"
+                    |> TextInput.withSmallSize
+                    |> TextInput.view []
+          , {}
+          )
         ]

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -10,7 +10,8 @@ module Nordea.Components.TextInput exposing
     , withPattern
     , withPlaceholder
     , withSearchIcon
-    , withSmallSize)
+    , withSmallSize
+    )
 
 import Css exposing (Style, absolute, backgroundColor, border3, borderBox, borderRadius, boxSizing, color, disabled, displayFlex, focus, fontSize, height, left, none, num, opacity, outline, padding2, paddingLeft, pct, pointerEvents, position, relative, rem, solid, top, transform, translateY, width)
 import Html.Styled as Html exposing (Attribute, Html, input, styled)

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -10,7 +10,7 @@ module Nordea.Components.TextInput exposing
     , withPattern
     , withPlaceholder
     , withSearchIcon
-    )
+    , withSmallSize)
 
 import Css exposing (Style, absolute, backgroundColor, border3, borderBox, borderRadius, boxSizing, color, disabled, displayFlex, focus, fontSize, height, left, none, num, opacity, outline, padding2, paddingLeft, pct, pointerEvents, position, relative, rem, solid, top, transform, translateY, width)
 import Html.Styled as Html exposing (Attribute, Html, input, styled)
@@ -38,7 +38,13 @@ type alias Config msg =
     , hasSearchIcon : Bool
     , onBlur : Maybe msg
     , onEnterPress : Maybe msg
+    , size : Size
     }
+
+
+type Size
+    = Small
+    | Large
 
 
 type TextInput msg
@@ -57,6 +63,7 @@ init value =
         , hasSearchIcon = False
         , onBlur = Nothing
         , onEnterPress = Nothing
+        , size = Large
         }
 
 
@@ -98,6 +105,11 @@ withOnBlur msg (TextInput config) =
 withOnEnterPress : msg -> TextInput msg -> TextInput msg
 withOnEnterPress msg (TextInput config) =
     TextInput { config | onEnterPress = Just msg }
+
+
+withSmallSize : TextInput msg -> TextInput msg
+withSmallSize (TextInput config) =
+    TextInput { config | size = Small }
 
 
 onEnterPress : msg -> Attribute msg
@@ -186,7 +198,14 @@ getStyles config =
                 Colors.grayMedium
     in
     [ fontSize (rem 1)
-    , height (rem 3)
+    , height
+        (case config.size of
+            Small ->
+                rem 2.5625
+
+            Large ->
+                rem 3
+        )
     , padding2 (rem 0.75) (rem 0.75)
     , borderRadius (rem 0.25)
     , border3 (rem 0.0625) solid borderColorStyle |> Css.important


### PR DESCRIPTION
Add "small" version of input fields #144

<img width="937" alt="image" src="https://user-images.githubusercontent.com/21218279/160398619-a5fb23da-63f5-4a81-866d-810868611684.png">

<img width="902" alt="image" src="https://user-images.githubusercontent.com/21218279/160398643-9c52e341-6300-4546-a758-633784d0ff74.png">

The difference between 48px(3 rem) and 41px(2.5625 rem) is not that, I guess.