### PR TITLE
PAR-Add-card-infobox: Addded infoBox component to Card component

### DIFF
--- a/explorer/src/Stories/Card.elm
+++ b/explorer/src/Stories/Card.elm
@@ -1,7 +1,11 @@
 module Stories.Card exposing (..)
 
+import Css exposing (alignItems, center, rem, width)
 import Html.Styled as Html
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card
+import Nordea.Html as Html
+import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -29,6 +33,26 @@ stories =
                     |> Card.withTitle "Card title"
                     |> Card.withShadow
                     |> Card.view [] [ Html.text "Card content" ]
+          , {}
+          )
+        , ( "With title and infobox"
+          , \_ ->
+                Card.init
+                    |> Card.withTitle "Card title"
+                    |> Card.withShadow
+                    |> Card.view []
+                        [ Html.text "Card content"
+                        , Card.infoBox [ css [ Css.property "gap" "1rem" ] ]
+                            [ Html.row [ css [ alignItems center, Css.property "gap" "0.5rem" ] ]
+                                [ Icons.filledCheckmark [ css [ width (rem 1.5) ] ]
+                                , Html.text "Some completed task"
+                                ]
+                            , Html.row [ css [ alignItems center, Css.property "gap" "0.5rem" ] ]
+                                [ Icons.unfilledMark [ css [ width (rem 1.5) ] ]
+                                , Html.text "Some not completed task"
+                                ]
+                            ]
+                        ]
           , {}
           )
         ]

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -1,10 +1,30 @@
 module Nordea.Components.Card exposing (..)
 
-import Css exposing (auto, backgroundColor, borderRadius, borderStyle, column, displayFlex, flexDirection, fontSize, height, left, margin2, none, padding, rem, textAlign, width)
+import Css
+    exposing
+        ( auto
+        , backgroundColor
+        , border3
+        , borderRadius
+        , borderStyle
+        , column
+        , displayFlex
+        , flexDirection
+        , fontSize
+        , height
+        , left
+        , margin2
+        , none
+        , padding
+        , rem
+        , solid
+        , textAlign
+        , width
+        )
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Text as Text
-import Nordea.Html exposing (styleIf, viewMaybe)
+import Nordea.Html as Html exposing (styleIf, viewMaybe)
 import Nordea.Resources.Colors as Colors
 
 
@@ -69,6 +89,20 @@ cardTitle title =
             ]
             []
         ]
+
+
+infoBox : List (Attribute msg) -> List (Html msg) -> Html msg
+infoBox attrs content =
+    Html.column
+        ([ css
+            [ borderRadius (rem 0.5)
+            , border3 (rem 0.0625) solid Colors.grayLight
+            , padding (rem 1)
+            ]
+         ]
+            ++ attrs
+        )
+        content
 
 
 withTitle : String -> Card msg -> Card msg

--- a/src/Nordea/Html.elm
+++ b/src/Nordea/Html.elm
@@ -1,12 +1,36 @@
-module Nordea.Html exposing (nothing, showIf, styleIf, viewIfNotEmpty, viewMaybe)
+module Nordea.Html exposing
+    ( column
+    , nothing
+    , row
+    , showIf
+    , styleIf
+    , viewIfNotEmpty
+    , viewMaybe
+    )
 
-import Css exposing (Style)
-import Html.Styled as Html exposing (Html)
+import Css exposing (Style, displayFlex, flexDirection)
+import Html.Styled as Html exposing (Attribute, Html, div, styled)
 
 
 nothing : Html msg
 nothing =
     Html.text ""
+
+
+column : List (Attribute msg) -> List (Html msg) -> Html msg
+column =
+    styled div
+        [ displayFlex
+        , flexDirection Css.column
+        ]
+
+
+row : List (Attribute msg) -> List (Html msg) -> Html msg
+row =
+    styled div
+        [ displayFlex
+        , flexDirection Css.row
+        ]
 
 
 viewMaybe : (a -> Html msg) -> Maybe a -> Html msg


### PR DESCRIPTION
- Adds an `infoBox` component to the `Card` component concept

![Screenshot 2022-04-28 at 11 00 04](https://user-images.githubusercontent.com/11747383/165717139-455492ab-96ab-41c8-9a63-a484381257ed.png)
