### PR TITLE
Make tooltip overlay support generic content

### DIFF
--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -17,7 +17,7 @@ type FinancingVariant
 type alias Config =
     { accordion : Accordion
     , isModalOpen : Bool
-    , searchComponentInput : Maybe String
+    , searchComponentInput : String
     , searchHasFocus : Bool
     , isFeatureBoxOpen : Bool
     , isProgressBarCompleted : Bool
@@ -61,7 +61,7 @@ init =
                 , body = [ Html.text "This is an answer" ]
                 , open = False
                 }
-    , searchComponentInput = Nothing
+    , searchComponentInput = ""
     , searchHasFocus = False
     , isModalOpen = True
     , isFeatureBoxOpen = True
@@ -87,11 +87,11 @@ update msg config =
             { config | infoLabel = InfoLabel.update m config.infoLabel }
 
         SearchComponentInput input ->
-            { config | searchComponentInput = Just input }
+            { config | searchComponentInput = input }
 
         SearchComponentSelected item ->
             { config
-                | searchComponentInput = Just item.text
+                | searchComponentInput = item.text
                 , searchHasFocus = False
             }
 
@@ -99,11 +99,7 @@ update msg config =
             { config | searchHasFocus = value }
 
         OnClickClearSearchComponentInput ->
-            let
-                emptySearchString =
-                    config.searchComponentInput |> Maybe.map (\_ -> "")
-            in
-            { config | searchComponentInput = emptySearchString }
+            { config | searchComponentInput = "" }
 
         NoOp ->
             config

--- a/explorer/src/Stories/DropdownFilter.elm
+++ b/explorer/src/Stories/DropdownFilter.elm
@@ -57,7 +57,7 @@ stories =
                             SearchComponentInput
                             SearchComponentSelected
                             searchResult
-                            (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            model.customModel.searchComponentInput
                             OnClickClearSearchComponentInput
                 in
                 Html.div [ css [ displayFlex, flexDirection column ] ]
@@ -75,7 +75,7 @@ stories =
                             SearchComponentInput
                             SearchComponentSelected
                             removedGroups
-                            (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            model.customModel.searchComponentInput
                             OnClickClearSearchComponentInput
                             |> DropdownFilter.withHasFocus True
                 in
@@ -91,7 +91,7 @@ stories =
                             SearchComponentInput
                             SearchComponentSelected
                             searchResult
-                            (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            model.customModel.searchComponentInput
                             OnClickClearSearchComponentInput
                             |> DropdownFilter.withHasFocus model.customModel.searchHasFocus
                             |> DropdownFilter.withOnFocus SearchComponentFocus
@@ -108,7 +108,7 @@ stories =
                             SearchComponentInput
                             SearchComponentSelected
                             searchResult
-                            (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            model.customModel.searchComponentInput
                             OnClickClearSearchComponentInput
                             |> DropdownFilter.withIsLoading True
                             |> DropdownFilter.withHasFocus True

--- a/explorer/src/Stories/DropdownFilter.elm
+++ b/explorer/src/Stories/DropdownFilter.elm
@@ -1,7 +1,9 @@
 module Stories.DropdownFilter exposing (stories)
 
 import Config exposing (Config, FinancingVariant(..), Msg(..))
+import Css exposing (column, displayFlex, flexDirection)
 import Html.Styled as Html
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.DropdownFilter as DropdownFilter
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -58,9 +60,8 @@ stories =
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
                             OnClickClearSearchComponentInput
                 in
-                DropdownFilter.view
-                    defaultOptions
-                    []
+                Html.div [ css [ displayFlex, flexDirection column ] ]
+                    [ DropdownFilter.view [] defaultOptions ]
           , {}
           )
         , ( "focused without group"
@@ -76,11 +77,10 @@ stories =
                             removedGroups
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
                             OnClickClearSearchComponentInput
-                            |> DropdownFilter.withFocusState True
+                            |> DropdownFilter.withHasFocus True
                 in
-                DropdownFilter.view
-                    defaultOptions
-                    []
+                Html.div [ css [ displayFlex, flexDirection column ] ]
+                    [ DropdownFilter.view [] defaultOptions ]
           , {}
           )
         , ( "interactive with focus"
@@ -93,12 +93,28 @@ stories =
                             searchResult
                             (Maybe.withDefault "" model.customModel.searchComponentInput)
                             OnClickClearSearchComponentInput
-                            |> DropdownFilter.withFocusHandling "explorer" model.customModel.searchHasFocus SearchComponentFocus
+                            |> DropdownFilter.withHasFocus model.customModel.searchHasFocus
+                            |> DropdownFilter.withOnFocus SearchComponentFocus
                 in
-                Html.div []
-                    [ DropdownFilter.view defaultOptions []
-                    , Html.text "Some text"
-                    ]
+                Html.div [ css [ displayFlex, flexDirection column ] ]
+                    [ DropdownFilter.view [] defaultOptions ]
+          , {}
+          )
+        , ( "Loading"
+          , \model ->
+                let
+                    defaultOptions =
+                        DropdownFilter.init
+                            SearchComponentInput
+                            SearchComponentSelected
+                            searchResult
+                            (Maybe.withDefault "" model.customModel.searchComponentInput)
+                            OnClickClearSearchComponentInput
+                            |> DropdownFilter.withIsLoading True
+                            |> DropdownFilter.withHasFocus True
+                in
+                Html.div [ css [ displayFlex, flexDirection column ] ]
+                    [ DropdownFilter.view [] defaultOptions ]
           , {}
           )
         , ( "interactive with async"

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -5,14 +5,15 @@ import Css
         ( alignItems
         , center
         , displayFlex
+        , height
+        , marginBottom
         , marginLeft
         , marginTop
-        , maxHeight
-        , maxWidth
         , overflowY
         , position
         , relative
         , rem
+        , width
         )
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
@@ -34,7 +35,7 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Top
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ text "here" ]
+                        |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
@@ -45,7 +46,7 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Bottom
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ text "here" ]
+                        |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
@@ -56,7 +57,7 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Left
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ text "here" ]
+                        |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
@@ -67,7 +68,7 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ text "here" ]
+                        |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
@@ -78,7 +79,7 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                        |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
@@ -90,7 +91,7 @@ stories =
                         |> Tooltip.withVisibility (FadeOutMs 3000)
                         |> Tooltip.withPlacement Right
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                        |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
@@ -102,33 +103,57 @@ stories =
                         |> Tooltip.withVisibility (FadeOutMs 5000)
                         |> Tooltip.withPlacement Right
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                        |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
         , ( "Card"
           , \_ ->
                 div []
-                    [ text "There is a tooltip "
-                    , Tooltip.init
-                        |> Tooltip.withPlacement Bottom
-                        |> Tooltip.withContent
-                            (\arrow ->
-                                Card.init
-                                    |> Card.withShadow
-                                    |> Card.view
-                                        [ css
-                                            [ maxHeight (rem 19)
-                                            , maxWidth (rem 19)
-                                            , marginTop (rem 1)
-                                            , position relative
+                    [ div [ css [ marginBottom (rem 10) ] ]
+                        [ text "There is a bottom tooltip "
+                        , Tooltip.init
+                            |> Tooltip.withPlacement Bottom
+                            |> Tooltip.withContent
+                                (\arrow ->
+                                    Card.init
+                                        |> Card.withShadow
+                                        |> Card.view
+                                            [ css
+                                                [ height (rem 18)
+                                                , width (rem 18)
+                                                , marginTop (rem 1)
+                                                , position relative
+                                                ]
                                             ]
-                                        ]
-                                        [ arrow []
-                                        , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
-                                        ]
-                            )
-                        |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                                            [ arrow []
+                                            , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
+                                            ]
+                                )
+                            |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                        ]
+                    , div []
+                        [ text "There is a right tooltip "
+                        , Tooltip.init
+                            |> Tooltip.withPlacement Right
+                            |> Tooltip.withContent
+                                (\arrow ->
+                                    Card.init
+                                        |> Card.withShadow
+                                        |> Card.view
+                                            [ css
+                                                [ height (rem 18)
+                                                , width (rem 18)
+                                                , marginLeft (rem 1)
+                                                , position relative
+                                                ]
+                                            ]
+                                            [ arrow []
+                                            , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
+                                            ]
+                                )
+                            |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                        ]
                     ]
           , {}
           )

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -13,6 +13,7 @@ import Css
         , position
         , relative
         , rem
+        , scroll
         , width
         )
 import Html.Styled exposing (div, text)
@@ -127,7 +128,7 @@ stories =
                                                 ]
                                             ]
                                             [ arrow []
-                                            , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
+                                            , div [ css [ overflowY scroll ] ] [ text lorem ]
                                             ]
                                 )
                             |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
@@ -149,7 +150,7 @@ stories =
                                                 ]
                                             ]
                                             [ arrow []
-                                            , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
+                                            , div [ css [ overflowY scroll ] ] [ text lorem ]
                                             ]
                                 )
                             |> Tooltip.view [] [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -1,8 +1,22 @@
 module Stories.Tooltip exposing (stories)
 
-import Css exposing (alignItems, center, displayFlex, marginLeft, rem)
+import Css
+    exposing
+        ( alignItems
+        , center
+        , displayFlex
+        , marginLeft
+        , marginTop
+        , maxHeight
+        , maxWidth
+        , overflowY
+        , position
+        , relative
+        , rem
+        )
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
+import Nordea.Components.Card as Card
 import Nordea.Components.Tooltip as Tooltip exposing (Placement(..), Visibility(..))
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
@@ -19,7 +33,7 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Top
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ text "here" ]
                     ]
           , {}
@@ -30,7 +44,7 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Bottom
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ text "here" ]
                     ]
           , {}
@@ -41,7 +55,7 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Left
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ text "here" ]
                     ]
           , {}
@@ -52,7 +66,7 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ text "here" ]
                     ]
           , {}
@@ -63,33 +77,63 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
-        , ( "With icon dissapear 3s"
+        , ( "With icon disappear 3s"
           , \_ ->
                 div [ css [ displayFlex, alignItems center ] ]
                     [ text "There is a tooltip "
                     , Tooltip.init
-                        |> Tooltip.withVisibility (DurationMs 3000)
+                        |> Tooltip.withVisibility (FadeOutMs 3000)
                         |> Tooltip.withPlacement Right
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
-        , ( "With icon dissapear 5s"
+        , ( "With icon disappear 5s"
           , \_ ->
                 div [ css [ displayFlex, alignItems center ] ]
                     [ text "There is a tooltip "
                     , Tooltip.init
-                        |> Tooltip.withVisibility (DurationMs 5000)
+                        |> Tooltip.withVisibility (FadeOutMs 5000)
                         |> Tooltip.withPlacement Right
-                        |> Tooltip.withContent [ text "This is a tooltip" ]
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
+                    ]
+          , {}
+          )
+        , ( "Card"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement Bottom
+                        |> Tooltip.withContent
+                            (\arrow ->
+                                Card.init
+                                    |> Card.withShadow
+                                    |> Card.view
+                                        [ css
+                                            [ maxHeight (rem 19)
+                                            , maxWidth (rem 19)
+                                            , marginTop (rem 1)
+                                            , position relative
+                                            ]
+                                        ]
+                                        [ arrow []
+                                        , div [ css [ overflowY Css.scroll ] ] [ text lorem ]
+                                        ]
+                            )
                         |> Tooltip.view [ Icons.questionMark [ css [ marginLeft (rem 0.25) ] ] ]
                     ]
           , {}
           )
         ]
+
+
+lorem =
+    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -19,6 +19,7 @@ import Css
         , border3
         , borderColor
         , borderRadius
+        , borderStyle
         , color
         , focus
         , fontFamilies
@@ -209,7 +210,7 @@ view attrs (Dropdown config) =
                     border3 (rem 0.0625) solid Colors.grayMedium
 
                   else
-                    border none
+                    borderStyle none
                 , borderColor Colors.redDark |> styleIf config.hasError
                 , borderRadius (rem 0.25)
                 , focus

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -205,7 +205,11 @@ view attrs (Dropdown config) =
                 , backgroundColor transparent
                 , padding4 (rem 0.5) (rem 2) (rem 0.5) (rem 1)
                 , paddingRight (rem 3) |> styleIf (config.variant /= Simple)
-                , border3 (rem 0.0625) solid Colors.grayMedium |> styleIf (config.variant /= Simple || config.hasError)
+                , if config.variant /= Simple || config.hasError then
+                    border3 (rem 0.0625) solid Colors.grayMedium
+
+                  else
+                    border none
                 , borderColor Colors.redDark |> styleIf config.hasError
                 , borderRadius (rem 0.25)
                 , focus

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -15,25 +15,19 @@ module Nordea.Components.Dropdown exposing
 import Css
     exposing
         ( absolute
-        , alignItems
         , backgroundColor
         , border3
         , borderColor
         , borderRadius
-        , borderStyle
-        , center
         , color
-        , displayFlex
         , focus
         , fontFamilies
         , fontSize
         , height
-        , hidden
         , inherit
         , lineHeight
         , none
         , outline
-        , overflow
         , padding4
         , paddingRight
         , pct
@@ -198,17 +192,7 @@ view attrs (Dropdown config) =
                     NordeaCss.smallInputHeight
     in
     div
-        (css
-            [ displayFlex
-            , position relative
-            , border3 (rem 0.0625) solid Colors.grayMedium |> styleIf (config.variant /= Simple || config.hasError)
-            , borderColor Colors.redDark |> styleIf config.hasError
-            , borderRadius (rem 0.25)
-            , alignItems center
-            , overflow hidden
-            ]
-            :: attrs
-        )
+        (css [ position relative ] :: attrs)
         [ Html.select
             [ Events.on "change" decoder
             , Attrs.disabled isDisabled
@@ -221,7 +205,9 @@ view attrs (Dropdown config) =
                 , backgroundColor transparent
                 , padding4 (rem 0.5) (rem 2) (rem 0.5) (rem 1)
                 , paddingRight (rem 3) |> styleIf (config.variant /= Simple)
-                , borderStyle none
+                , border3 (rem 0.0625) solid Colors.grayMedium |> styleIf (config.variant /= Simple || config.hasError)
+                , borderColor Colors.redDark |> styleIf config.hasError
+                , borderRadius (rem 0.25)
                 , focus
                     [ Css.property "box-shadow" ("0rem 0rem 0rem 0.0625rem " ++ Themes.colorVariable Themes.SecondaryColor Colors.blueNordea)
                     , outline none
@@ -241,7 +227,7 @@ view attrs (Dropdown config) =
                         [ position absolute
                         , top (pct 50)
                         , transform (translateY (pct -50))
-                        , right (rem 0.25)
+                        , right (rem 0.3125)
                         , pointerEvents none
                         , color Colors.grayCool
                         ]

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -13,30 +13,24 @@ import Css
         ( absolute
         , alignItems
         , backgroundColor
-        , block
-        , border3
         , borderBottom3
         , borderBottomLeftRadius
         , borderBottomRightRadius
         , borderBox
-        , borderColor
         , borderLeft3
-        , borderRadius4
         , borderRight3
-        , boxShadow5
         , boxSizing
         , center
         , color
+        , column
         , cursor
-        , display
+        , deg
         , displayFlex
-        , focus
+        , flexDirection
         , fontSize
         , fontWeight
         , height
         , hover
-        , inherit
-        , inset
         , int
         , justifyContent
         , lineHeight
@@ -45,32 +39,34 @@ import Css
         , margin2
         , maxHeight
         , none
-        , outline
         , overflowY
         , padding
         , padding3
-        , padding4
         , paddingRight
         , pct
         , pointer
+        , pointerEvents
         , position
         , relative
         , rem
         , right
+        , rotate
         , scroll
         , solid
         , top
-        , transform
+        , transforms
         , translateY
         , width
         )
+import Css.Global exposing (descendants, typeSelector)
 import Html.Events.Extra as Events
 import Html.Styled as Html exposing (Html)
-import Html.Styled.Attributes as Attrs exposing (css, tabindex, type_, value)
+import Html.Styled.Attributes as Attrs exposing (css, tabindex, value)
 import Html.Styled.Events as Events
 import Json.Decode as Decode
 import Maybe.Extra as Maybe
 import Nordea.Components.Spinner as Spinner
+import Nordea.Components.TextInput as TextInput
 import Nordea.Components.Tooltip as Tooltip
 import Nordea.Html as Html exposing (styleIf)
 import Nordea.Resources.Colors as Colors
@@ -107,11 +103,6 @@ type DropdownFilter a msg
     = DropdownFilter (DropdownFilterProperties a msg)
 
 
-{-| Default Options, will give you empty dropdown with no empty item
-
-  - TODO handle isSearching - use with RemoteData to show that new data is loading
-
--}
 init : (String -> msg) -> (Item a -> msg) -> List (ItemGroup a) -> String -> msg -> DropdownFilter a msg
 init onSearchInput onSelectValue searchItems rawInputString onClickClearInput =
     DropdownFilter
@@ -150,6 +141,18 @@ view attrs (DropdownFilter config) =
 
         showHasNoMatch =
             config.rawInputString /= "" && List.isEmpty searchMatches
+
+        dropdownStyles =
+            Css.batch
+                [ backgroundColor Colors.white
+                , borderBottom3 (rem 0.0625) solid Colors.grayMedium
+                , borderLeft3 (rem 0.0625) solid Colors.grayMedium
+                , borderRight3 (rem 0.0625) solid Colors.grayMedium
+                , borderBottomLeftRadius (rem 0.25)
+                , borderBottomRightRadius (rem 0.25)
+                , boxSizing borderBox
+                , padding3 (rem 0.1875) (rem 0.0625) (rem 0.75)
+                ]
     in
     Tooltip.init
         |> Tooltip.withPlacement Tooltip.Bottom
@@ -165,16 +168,12 @@ view attrs (DropdownFilter config) =
                 if config.isLoading then
                     Html.div
                         [ css
-                            [ displayFlex
+                            [ height (rem 8)
+                            , displayFlex
+                            , flexDirection column
                             , justifyContent center
+                            , dropdownStyles
                             , alignItems center
-                            , height (rem 8)
-                            , backgroundColor Colors.white
-                            , borderBottom3 (rem 0.0625) solid Colors.grayMedium
-                            , borderLeft3 (rem 0.0625) solid Colors.grayMedium
-                            , borderRight3 (rem 0.0625) solid Colors.grayMedium
-                            , borderBottomLeftRadius (rem 0.25)
-                            , borderBottomRightRadius (rem 0.25)
                             ]
                         ]
                         [ Spinner.small [] ]
@@ -182,19 +181,11 @@ view attrs (DropdownFilter config) =
                 else
                     Html.ul
                         [ css
-                            [ display block
-                            , margin (rem 0)
+                            [ margin (rem 0)
                             , overflowY scroll
                             , maxHeight (rem 16.75)
                             , listStyle none
-                            , boxSizing borderBox
-                            , padding3 (rem 0.1875) (rem 0.0625) (rem 0.75)
-                            , backgroundColor Colors.white
-                            , borderBottom3 (rem 0.0625) solid Colors.grayMedium
-                            , borderLeft3 (rem 0.0625) solid Colors.grayMedium
-                            , borderRight3 (rem 0.0625) solid Colors.grayMedium
-                            , borderBottomLeftRadius (rem 0.25)
-                            , borderBottomRightRadius (rem 0.25)
+                            , dropdownStyles
                             ]
                         ]
                         searchMatches
@@ -223,60 +214,54 @@ view attrs (DropdownFilter config) =
 inputSearchView : Bool -> Bool -> String -> (String -> msg) -> msg -> Html msg
 inputSearchView hasError hasFocus searchString onInput onClickClearInput =
     Html.div
-        [ css
-            [ displayFlex
-            , position relative
-            ]
-        ]
-        [ Html.input
-            [ type_ "text"
-            , Events.onInput onInput
-            , value searchString
-            , css
-                [ padding4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 1)
-                , border3 (rem 0.0625) solid Colors.grayMedium
-                , borderColor Colors.redDark |> styleIf hasError
-                , width (pct 100)
-                , boxSizing borderBox
-                , backgroundColor Colors.white
-                , focus
-                    [ backgroundColor Colors.grayCool
-                    , outline none
-                    , border3 (rem 0.0625) solid Colors.blueNordea
+        [ css [ position relative ] ]
+        [ TextInput.init searchString
+            |> TextInput.withError hasError
+            |> TextInput.withOnInput onInput
+            |> TextInput.view
+                [ css
+                    [ width (pct 100)
+                    , borderBottomLeftRadius (pct 0) |> Css.important |> styleIf hasFocus
+                    , borderBottomRightRadius (pct 0) |> Css.important |> styleIf hasFocus
+                    , descendants [ typeSelector "input" [ paddingRight (rem 3) ] ]
                     ]
-                , if hasFocus then
-                    borderRadius4 (rem 0.25) (rem 0.25) (rem 0) (rem 0)
-
-                  else
-                    borderRadius4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0.25)
-                , boxShadow5 inset (rem 0) (rem -0.0625) (rem 0) Colors.grayLight
-                , height (rem 3)
-                , paddingRight (rem 2)
                 ]
-            ]
-            []
-        , let
-            attributes =
+        , if String.length searchString > 0 then
+            Icon.cross
+                [ Events.onClick onClickClearInput
+                , css
+                    [ position absolute
+                    , top (pct 50)
+                    , right (rem 0.75)
+                    , transforms [ translateY (pct -50) ]
+                    , width (rem 1.125)
+                    , cursor pointer
+                    ]
+                ]
+
+          else if hasFocus then
+            Icon.chevronDownFilled
                 [ css
                     [ position absolute
                     , top (pct 50)
-                    , transform (translateY (pct -50))
-                    , right (rem 0.75)
-                    , width (rem 1.125) |> Css.important
-                    , height (rem 1.125)
-                    , cursor pointer
-                    , color inherit
+                    , right (rem 0.3125)
+                    , transforms [ translateY (pct -50), rotate (deg 180) ]
+                    , pointerEvents none
+                    , color Colors.grayCool
                     ]
                 ]
-          in
-          if String.length searchString > 0 then
-            Icon.cross (attributes ++ [ Events.onClick onClickClearInput, css [ width (rem 1.385) ] ])
-
-          else if hasFocus then
-            Icon.chevronUp attributes
 
           else
-            Icon.chevronDown attributes
+            Icon.chevronDownFilled
+                [ css
+                    [ position absolute
+                    , top (pct 50)
+                    , right (rem 0.3125)
+                    , transforms [ translateY (pct -50) ]
+                    , pointerEvents none
+                    , color Colors.grayCool
+                    ]
+                ]
         ]
 
 

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -47,7 +47,6 @@ import Css
         , pointer
         , pointerEvents
         , position
-        , relative
         , rem
         , right
         , rotate

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -202,67 +202,46 @@ view attrs (DropdownFilter config) =
              )
                 ++ attrs
             )
-            [ inputSearchView
-                (config.hasError || showHasNoMatch)
-                config.hasFocus
-                config.rawInputString
-                config.onSearchInput
-                config.onClickClearInput
+            [ TextInput.init config.rawInputString
+                |> TextInput.withError (config.hasError || showHasNoMatch)
+                |> TextInput.withOnInput config.onSearchInput
+                |> TextInput.view
+                    [ css
+                        [ width (pct 100)
+                        , borderBottomLeftRadius (pct 0) |> Css.important |> styleIf config.hasFocus
+                        , borderBottomRightRadius (pct 0) |> Css.important |> styleIf config.hasFocus
+                        , descendants [ typeSelector "input" [ paddingRight (rem 3) ] ]
+                        ]
+                    ]
+            , if String.length config.rawInputString > 0 then
+                Icon.cross
+                    [ Events.onClick config.onClickClearInput
+                    , css
+                        [ position absolute
+                        , top (pct 50)
+                        , right (rem 0.75)
+                        , transforms [ translateY (pct -50) ]
+                        , width (rem 1.125)
+                        , cursor pointer
+                        ]
+                    ]
+
+              else
+                Icon.chevronDownFilled
+                    [ css
+                        [ position absolute
+                        , top (pct 50)
+                        , right (rem 0.3125)
+                        , if config.hasFocus then
+                            transforms [ translateY (pct -50), rotate (deg 180) ]
+
+                          else
+                            transforms [ translateY (pct -50) ]
+                        , pointerEvents none
+                        , color Colors.grayCool
+                        ]
+                    ]
             ]
-
-
-inputSearchView : Bool -> Bool -> String -> (String -> msg) -> msg -> Html msg
-inputSearchView hasError hasFocus searchString onInput onClickClearInput =
-    Html.div
-        [ css [ position relative ] ]
-        [ TextInput.init searchString
-            |> TextInput.withError hasError
-            |> TextInput.withOnInput onInput
-            |> TextInput.view
-                [ css
-                    [ width (pct 100)
-                    , borderBottomLeftRadius (pct 0) |> Css.important |> styleIf hasFocus
-                    , borderBottomRightRadius (pct 0) |> Css.important |> styleIf hasFocus
-                    , descendants [ typeSelector "input" [ paddingRight (rem 3) ] ]
-                    ]
-                ]
-        , if String.length searchString > 0 then
-            Icon.cross
-                [ Events.onClick onClickClearInput
-                , css
-                    [ position absolute
-                    , top (pct 50)
-                    , right (rem 0.75)
-                    , transforms [ translateY (pct -50) ]
-                    , width (rem 1.125)
-                    , cursor pointer
-                    ]
-                ]
-
-          else if hasFocus then
-            Icon.chevronDownFilled
-                [ css
-                    [ position absolute
-                    , top (pct 50)
-                    , right (rem 0.3125)
-                    , transforms [ translateY (pct -50), rotate (deg 180) ]
-                    , pointerEvents none
-                    , color Colors.grayCool
-                    ]
-                ]
-
-          else
-            Icon.chevronDownFilled
-                [ css
-                    [ position absolute
-                    , top (pct 50)
-                    , right (rem 0.3125)
-                    , transforms [ translateY (pct -50) ]
-                    , pointerEvents none
-                    , color Colors.grayCool
-                    ]
-                ]
-        ]
 
 
 headerView : String -> Html msg

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -14,7 +14,40 @@ module Nordea.Components.TextInput exposing
     , withSmallSize
     )
 
-import Css exposing (Style, absolute, backgroundColor, border3, borderBox, borderRadius, boxSizing, color, disabled, displayFlex, focus, fontSize, height, left, none, num, opacity, outline, padding2, paddingLeft, pct, pointerEvents, position, relative, rem, right, solid, top, transform, translateY, width)
+import Css
+    exposing
+        ( Style
+        , absolute
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderRadius
+        , boxSizing
+        , color
+        , disabled
+        , displayFlex
+        , focus
+        , fontSize
+        , height
+        , left
+        , none
+        , num
+        , opacity
+        , outline
+        , padding2
+        , paddingLeft
+        , pct
+        , pointerEvents
+        , position
+        , relative
+        , rem
+        , right
+        , solid
+        , top
+        , transform
+        , translateY
+        , width
+        )
 import Html.Styled as Html exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes exposing (css, maxlength, pattern, placeholder, value)
 import Html.Styled.Events exposing (keyCode, on, onBlur, onInput)
@@ -22,7 +55,7 @@ import Json.Decode as Json
 import Maybe.Extra as Maybe
 import Nordea.Components.Text as Text
 import Nordea.Css as NordeaCss
-import Nordea.Html exposing (styleIf)
+import Nordea.Html as Html exposing (styleIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.Icons as Icons
 import Nordea.Themes as Themes
@@ -177,9 +210,7 @@ view attributes (TextInput config) =
 
     else
         Html.div
-            (css [ displayFlex, position relative ]
-                :: attributes
-            )
+            (css [ displayFlex, position relative ] :: attributes)
             [ styled input
                 (getStyles config)
                 (getAttributes config ++ attributes)
@@ -190,20 +221,23 @@ view attributes (TextInput config) =
 
 viewCurrency : Config msg -> Html msg
 viewCurrency config =
-    let
-        currency =
-            config.currency |> Maybe.withDefault "" |> String.slice 0 3 |> String.toUpper
-    in
-    Html.div
-        [ css
-            [ position absolute
-            , right (rem 0.7)
-            , top (pct 30)
-            ]
-        ]
-        [ Text.textHeavy
-            |> Text.view [] [ Html.text currency ]
-        ]
+    config.currency
+        |> Html.viewMaybe
+            (\currency ->
+                Text.textHeavy
+                    |> Text.view
+                        [ css
+                            [ position absolute
+                            , right (rem 0.7)
+                            , top (pct 30)
+                            ]
+                        ]
+                        [ currency
+                            |> String.slice 0 3
+                            |> String.toUpper
+                            |> Html.text
+                        ]
+            )
 
 
 getAttributes : Config msg -> List (Attribute msg)

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -1,11 +1,60 @@
-module Nordea.Components.Tooltip exposing (..)
+module Nordea.Components.Tooltip exposing
+    ( Placement(..)
+    , Tooltip
+    , Visibility(..)
+    , infoTooltip
+    , init
+    , view
+    , withContent
+    , withPlacement
+    , withVisibility
+    )
 
-import Css exposing (Style, animationDuration, animationName, deg, int, ms, opacity, pct, rem, zero)
+import Css
+    exposing
+        ( absolute
+        , animationDuration
+        , animationName
+        , backgroundColor
+        , block
+        , borderRadius
+        , bottom
+        , boxShadow4
+        , color
+        , column
+        , deg
+        , display
+        , displayFlex
+        , flexDirection
+        , height
+        , hover
+        , inherit
+        , int
+        , left
+        , maxWidth
+        , ms
+        , none
+        , padding2
+        , pct
+        , position
+        , relative
+        , rem
+        , rgba
+        , right
+        , rotate
+        , top
+        , transform
+        , transforms
+        , translate2
+        , translateX
+        , translateY
+        , width
+        , zero
+        )
 import Css.Animations as Animations exposing (keyframes)
-import Css.Global as Css
-import Css.Transitions exposing (transition)
-import Html.Styled exposing (Html, div, span, styled)
-import Html.Styled.Attributes as Attr
+import Css.Global exposing (class, descendants)
+import Html.Styled as Html exposing (Attribute, Html)
+import Html.Styled.Attributes as Attr exposing (css)
 import Nordea.Resources.Colors as Colors
 
 
@@ -17,13 +66,15 @@ type Placement
 
 
 type Visibility
-    = Always
-    | DurationMs Float
+    = OnHoverFocus
+    | FadeOutMs Float
+    | Show
+    | Hidden
 
 
 type alias Config msg =
     { placement : Placement
-    , content : List (Html msg)
+    , content : (List (Attribute msg) -> Html msg) -> Html msg
     , visibility : Visibility
     }
 
@@ -36,8 +87,8 @@ init : Tooltip msg
 init =
     Tooltip
         { placement = Top
-        , content = []
-        , visibility = Always
+        , content = \_ -> Html.text ""
+        , visibility = OnHoverFocus
         }
 
 
@@ -46,7 +97,10 @@ withPlacement placement (Tooltip config) =
     Tooltip { config | placement = placement }
 
 
-withContent : List (Html msg) -> Tooltip msg -> Tooltip msg
+withContent :
+    ((List (Attribute msg) -> Html msg) -> Html msg)
+    -> Tooltip msg
+    -> Tooltip msg
 withContent content (Tooltip config) =
     Tooltip { config | content = content }
 
@@ -59,122 +113,159 @@ withVisibility visibility (Tooltip config) =
 view : List (Html msg) -> Tooltip msg -> Html msg
 view children (Tooltip config) =
     let
-        animation =
-            keyframes
-                [ ( 0, [ Animations.opacity (int 1) ] )
-                , ( 10, [ Animations.opacity (int 1) ] )
-                , ( 90, [ Animations.opacity (int 1) ] )
-                , ( 100, [ Animations.opacity (int 0) ] )
-                ]
-    in
-    styled span
-        [ Css.position Css.relative
-        , Css.hover
-            [ Css.descendants
-                [ Css.class "tooltip"
-                    [ case config.visibility of
-                        DurationMs duration ->
+        arrow arrowAttrs =
+            let
+                arrowPosition =
+                    case config.placement of
+                        Top ->
                             Css.batch
-                                [ opacity (int 0)
-                                , animationName animation
-                                , animationDuration (ms duration)
+                                [ bottom (rem -0.3125)
+                                , left (pct 50)
+                                , transforms [ translateX (pct -50), rotate (deg 45) ]
                                 ]
 
-                        Always ->
-                            Css.opacity (int 1)
+                        Bottom ->
+                            Css.batch
+                                [ top (rem -0.3125)
+                                , left (pct 50)
+                                , transforms [ translateX (pct -50), rotate (deg 45) ]
+                                ]
+
+                        Left ->
+                            Css.batch
+                                [ right (rem -0.3125)
+                                , top (pct 50)
+                                , transforms [ translateY (pct -50), rotate (deg 45) ]
+                                ]
+
+                        Right ->
+                            Css.batch
+                                [ left (rem -0.3125)
+                                , top (pct 50)
+                                , transforms [ translateY (pct -50), rotate (deg 45) ]
+                                ]
+            in
+            Html.div
+                (css
+                    [ display block
+                    , position absolute
+                    , arrowPosition
+                    , width (rem 0.625)
+                    , height (rem 0.625)
+                    , backgroundColor inherit
+                    ]
+                    :: arrowAttrs
+                )
+                []
+
+        tooltipContainer =
+            let
+                tooltipPosition =
+                    case config.placement of
+                        Top ->
+                            Css.batch
+                                [ top (rem 0)
+                                , left (pct 50)
+                                , transform (translate2 (pct -50) (pct -100))
+                                ]
+
+                        Bottom ->
+                            Css.batch
+                                [ bottom (rem 0)
+                                , left (pct 50)
+                                , transform (translate2 (pct -50) (pct 100))
+                                ]
+
+                        Left ->
+                            Css.batch
+                                [ left (rem 0)
+                                , top (pct 50)
+                                , transform (translate2 (pct -100) (pct -50))
+                                ]
+
+                        Right ->
+                            Css.batch
+                                [ right (rem 0)
+                                , top (pct 50)
+                                , transform (translate2 (pct 100) (pct -50))
+                                ]
+            in
+            Html.div
+                [ Attr.class "tooltip"
+                , css
+                    [ position absolute
+                    , display none
+                    , flexDirection column
+                    , tooltipPosition
+                    , case config.visibility of
+                        FadeOutMs duration ->
+                            Css.batch
+                                [ displayFlex
+                                , animationDuration (ms duration)
+                                , Css.property "animation-fill-mode" "forwards"
+
+                                -- left moves it out of dom, visibility hides it from screen readers
+                                , animationName
+                                    (keyframes
+                                        [ ( 0, [ Animations.opacity (int 1) ] )
+                                        , ( 90, [ Animations.opacity (int 1) ] )
+                                        , ( 99
+                                          , [ Animations.opacity (int 0)
+                                            , Animations.property "left" "unset"
+                                            , Animations.property "visibility" "unset"
+                                            ]
+                                          )
+                                        , ( 100
+                                          , [ Animations.opacity (int 0)
+                                            , Animations.property "left" "-99999rem"
+                                            , Animations.property "visibility" "hidden"
+                                            ]
+                                          )
+                                        ]
+                                    )
+                                ]
+
+                        Show ->
+                            displayFlex
+
+                        _ ->
+                            Css.batch []
+                    ]
+                ]
+    in
+    Html.span
+        [ css
+            [ position relative
+            , hover
+                [ descendants
+                    [ class "tooltip"
+                        [ case config.visibility of
+                            OnHoverFocus ->
+                                displayFlex
+
+                            _ ->
+                                Css.batch []
+                        ]
                     ]
                 ]
             ]
         ]
-        []
-        (children
-            ++ [ styled div
-                    [ Css.position Css.absolute
-                    , Css.backgroundColor Colors.grayDarkest
-                    , Css.color Colors.white
-                    , Css.padding2 (rem 0.5) (rem 1)
-                    , Css.borderRadius (rem 0.5)
-                    , Css.boxShadow4 zero (rem 0.0625) (rem 0.125) (Css.rgba 0 0 0 0.2)
-                    , Css.property "width" "max-content"
-                    , Css.maxWidth (rem 20)
-                    , Css.pointerEvents Css.none
-                    , Css.opacity zero
-                    , transition [ Css.Transitions.opacity 150 ]
-                    , tooltipContentStyle config.placement
-                    , Css.before
-                        [ Css.property "content" "' '"
-                        , Css.width (rem 0.625)
-                        , Css.height (rem 0.625)
-                        , Css.backgroundColor Css.inherit
-                        , Css.position Css.absolute
-                        , arrowStyle config.placement
-                        ]
-                    ]
-                    [ Attr.class "tooltip" ]
-                    config.content
-               ]
+        (children ++ [ tooltipContainer [ config.content arrow ] ])
+
+
+infoTooltip : List (Attribute msg) -> List (Html msg) -> (List (Attribute msg) -> Html msg) -> Html msg
+infoTooltip attrs children arrow =
+    Html.div
+        (css
+            [ backgroundColor Colors.grayDarkest
+            , color Colors.white
+            , padding2 (rem 0.5) (rem 1)
+            , borderRadius (rem 0.5)
+            , boxShadow4 zero (rem 0.0625) (rem 0.125) (rgba 0 0 0 0.2)
+            , Css.property "width" "max-content"
+            , maxWidth (rem 20)
+            , position relative
+            ]
+            :: attrs
         )
-
-
-tooltipContentStyle : Placement -> Style
-tooltipContentStyle placement =
-    case placement of
-        Top ->
-            Css.batch
-                [ Css.top (rem -1)
-                , Css.left (pct 50)
-                , Css.transform (Css.translate2 (pct -50) (pct -100))
-                ]
-
-        Bottom ->
-            Css.batch
-                [ Css.bottom (rem -1)
-                , Css.left (pct 50)
-                , Css.transform (Css.translate2 (pct -50) (pct 100))
-                ]
-
-        Left ->
-            Css.batch
-                [ Css.left (rem -1)
-                , Css.top (pct 50)
-                , Css.transform (Css.translate2 (pct -100) (pct -50))
-                ]
-
-        Right ->
-            Css.batch
-                [ Css.right (rem -1)
-                , Css.top (pct 50)
-                , Css.transform (Css.translate2 (pct 100) (pct -50))
-                ]
-
-
-arrowStyle : Placement -> Style
-arrowStyle placement =
-    case placement of
-        Top ->
-            Css.batch
-                [ Css.bottom (rem -0.3125)
-                , Css.left (pct 50)
-                , Css.transforms [ Css.translateX (pct -50), Css.rotate (deg 45) ]
-                ]
-
-        Bottom ->
-            Css.batch
-                [ Css.top (rem -0.3125)
-                , Css.left (pct 50)
-                , Css.transforms [ Css.translateX (pct -50), Css.rotate (deg 45) ]
-                ]
-
-        Left ->
-            Css.batch
-                [ Css.right (rem -0.3125)
-                , Css.top (pct 50)
-                , Css.transforms [ Css.translateY (pct -50), Css.rotate (deg 45) ]
-                ]
-
-        Right ->
-            Css.batch
-                [ Css.left (rem -0.3125)
-                , Css.top (pct 50)
-                , Css.transforms [ Css.translateY (pct -50), Css.rotate (deg 45) ]
-                ]
+        (arrow [] :: children)

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -33,7 +33,12 @@ import Css
         , inlineFlex
         , int
         , left
+        , marginBottom
+        , marginLeft
+        , marginRight
+        , marginTop
         , maxWidth
+        , minWidth
         , ms
         , none
         , padding2
@@ -202,7 +207,7 @@ view attrs children (Tooltip config) =
                     , display none
                     , flexDirection column
                     , zIndex (int 10)
-                    , width (pct 100)
+                    , minWidth (pct 100)
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->
@@ -254,6 +259,22 @@ view attrs children (Tooltip config) =
                 |> styleIf (config.visibility == OnHoverFocus)
             , pseudoClass "focus-within" [ descendants [ showTooltipOnHover ] ]
                 |> styleIf (config.visibility == OnHoverFocus)
+            , descendants
+                [ class "tooltip-content-default-margin"
+                    [ case config.placement of
+                        Top ->
+                            marginBottom (rem 1)
+
+                        Bottom ->
+                            marginTop (rem 1)
+
+                        Left ->
+                            marginRight (rem 1)
+
+                        Right ->
+                            marginLeft (rem 1)
+                    ]
+                ]
             ]
             :: attrs
         )
@@ -263,7 +284,8 @@ view attrs children (Tooltip config) =
 infoTooltip : List (Attribute msg) -> List (Html msg) -> (List (Attribute msg) -> Html msg) -> Html msg
 infoTooltip attrs children arrow =
     Html.div
-        (css
+        ([ Attr.class "tooltip-content-default-margin"
+         , css
             [ backgroundColor Colors.grayDarkest
             , color Colors.white
             , padding2 (rem 0.5) (rem 1)
@@ -273,6 +295,7 @@ infoTooltip attrs children arrow =
             , maxWidth (rem 20)
             , position relative
             ]
-            :: attrs
+         ]
+            ++ attrs
         )
         (arrow [] :: children)

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -13,6 +13,7 @@ module Nordea.Components.Tooltip exposing
 import Css
     exposing
         ( absolute
+        , active
         , animationDuration
         , animationName
         , backgroundColor
@@ -29,6 +30,7 @@ import Css
         , height
         , hover
         , inherit
+        , inlineFlex
         , int
         , left
         , maxWidth
@@ -37,6 +39,7 @@ import Css
         , padding2
         , pct
         , position
+        , pseudoClass
         , relative
         , rem
         , rgba
@@ -49,12 +52,14 @@ import Css
         , translateX
         , translateY
         , width
+        , zIndex
         , zero
         )
 import Css.Animations as Animations exposing (keyframes)
 import Css.Global exposing (class, descendants)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attr exposing (css)
+import Nordea.Html exposing (styleIf)
 import Nordea.Resources.Colors as Colors
 
 
@@ -110,8 +115,8 @@ withVisibility visibility (Tooltip config) =
     Tooltip { config | visibility = visibility }
 
 
-view : List (Html msg) -> Tooltip msg -> Html msg
-view children (Tooltip config) =
+view : List (Attribute msg) -> List (Html msg) -> Tooltip msg -> Html msg
+view attrs children (Tooltip config) =
     let
         arrow arrowAttrs =
             let
@@ -196,6 +201,8 @@ view children (Tooltip config) =
                     [ position absolute
                     , display none
                     , flexDirection column
+                    , zIndex (int 10)
+                    , width (pct 100)
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->
@@ -232,24 +239,24 @@ view children (Tooltip config) =
                             Css.batch []
                     ]
                 ]
-    in
-    Html.span
-        [ css
-            [ position relative
-            , hover
-                [ descendants
-                    [ class "tooltip"
-                        [ case config.visibility of
-                            OnHoverFocus ->
-                                displayFlex
 
-                            _ ->
-                                Css.batch []
-                        ]
-                    ]
-                ]
+        showTooltipOnHover =
+            class "tooltip" [ displayFlex ]
+    in
+    Html.div
+        (css
+            [ display inlineFlex
+            , flexDirection column
+            , position relative
+            , hover [ descendants [ showTooltipOnHover ] ]
+                |> styleIf (config.visibility == OnHoverFocus)
+            , active [ descendants [ showTooltipOnHover ] ]
+                |> styleIf (config.visibility == OnHoverFocus)
+            , pseudoClass "focus-within" [ descendants [ showTooltipOnHover ] ]
+                |> styleIf (config.visibility == OnHoverFocus)
             ]
-        ]
+            :: attrs
+        )
         (children ++ [ tooltipContainer [ config.content arrow ] ])
 
 

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -129,39 +129,40 @@ view attrs children (Tooltip config) =
                     case config.placement of
                         Top ->
                             Css.batch
-                                [ bottom (rem -0.3125)
+                                [ bottom (rem -0.66)
                                 , left (pct 50)
-                                , transforms [ translateX (pct -50), rotate (deg 45) ]
+                                , transforms [ translateX (pct -50), rotate (deg 180) ]
                                 ]
 
                         Bottom ->
                             Css.batch
-                                [ top (rem -0.3125)
+                                [ top (rem -0.66)
                                 , left (pct 50)
-                                , transforms [ translateX (pct -50), rotate (deg 45) ]
+                                , transforms [ translateX (pct -50) ]
                                 ]
 
                         Left ->
                             Css.batch
-                                [ right (rem -0.3125)
+                                [ right (rem -0.66)
                                 , top (pct 50)
-                                , transforms [ translateY (pct -50), rotate (deg 45) ]
+                                , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
                         Right ->
                             Css.batch
-                                [ left (rem -0.3125)
+                                [ left (rem -0.66)
                                 , top (pct 50)
-                                , transforms [ translateY (pct -50), rotate (deg 45) ]
+                                , transforms [ translateY (pct -50), rotate (deg -90) ]
                                 ]
             in
             Html.div
                 (css
                     [ display block
                     , position absolute
+                    , Css.property "clip-path" "polygon(50% 20%, 100% 70%, 0 70%)"
                     , arrowPosition
-                    , width (rem 0.625)
-                    , height (rem 0.625)
+                    , width (rem 1)
+                    , height (rem 1)
                     , backgroundColor inherit
                     ]
                     :: arrowAttrs


### PR DESCRIPTION
* Support for generic content in the Tooltip component
  * Based on https://github.com/SGFinansAS/elm-components/pull/204 and the requirements from PartnerHub
* Make DropdownFilter use the Tooltip component
* Simplify focus logic in DropdownFilter component
* Fix Tooltip fade out animation


<img width="728" alt="Screenshot 2022-06-27 at 16 20 09" src="https://user-images.githubusercontent.com/42603101/175963610-e7371ea0-4006-4ce5-baa0-7ca9b23c39ee.png">

