### PR TITLE
Fix: Slider - stupid explorer default styling

### DIFF
--- a/src/Nordea/Components/Slider.elm
+++ b/src/Nordea/Components/Slider.elm
@@ -8,7 +8,20 @@ module Nordea.Components.Slider exposing
     , withStep
     )
 
-import Css exposing (border, color, column, displayFlex, flex, flexDirection, int, margin, marginBottom, padding, rem)
+import Css
+    exposing
+        ( border
+        , color
+        , column
+        , displayFlex
+        , flex
+        , flexDirection
+        , int
+        , margin
+        , marginBottom
+        , padding
+        , rem
+        )
 import Html.Styled as Html
     exposing
         ( Attribute

--- a/src/Nordea/Components/Slider.elm
+++ b/src/Nordea/Components/Slider.elm
@@ -8,17 +8,7 @@ module Nordea.Components.Slider exposing
     , withStep
     )
 
-import Css
-    exposing
-        ( color
-        , column
-        , displayFlex
-        , flex
-        , flexDirection
-        , int
-        , marginBottom
-        , rem
-        )
+import Css exposing (border, color, column, displayFlex, flex, flexDirection, int, margin, marginBottom, padding, rem)
 import Html.Styled as Html
     exposing
         ( Attribute
@@ -102,7 +92,17 @@ withShowNumberInput value (Slider config) =
 
 view : List (Attribute msg) -> Slider msg -> Html msg
 view attributes (Slider config) =
-    fieldset ([ css [ displayFlex, flexDirection column ] ] ++ attributes)
+    fieldset
+        ([ css
+            [ displayFlex
+            , flexDirection column
+            , border (rem 0)
+            , padding (rem 0)
+            , margin (rem 0)
+            ]
+         ]
+            ++ attributes
+        )
         [ div [ css [ displayFlex, marginBottom (rem 0.5) ] ]
             [ legend [ css [ flex (int 3) ] ]
                 [ NordeaText.textSmallLight


### PR DESCRIPTION
Fixes the Slider's default fieldset border styling because Storybook Explorer hides it