### PR TITLE
PAR-Add-hide-if-function

### DIFF
--- a/src/Nordea/Html.elm
+++ b/src/Nordea/Html.elm
@@ -1,5 +1,6 @@
 module Nordea.Html exposing
     ( column
+    , hideIf
     , nothing
     , row
     , showIf
@@ -50,6 +51,15 @@ showIf condition element =
 
     else
         nothing
+
+
+hideIf : Bool -> Html msg -> Html msg
+hideIf condition html =
+    if condition then
+        nothing
+
+    else
+        html
 
 
 viewIfNotEmpty : List a -> (List a -> Html msg) -> Html msg


### PR DESCRIPTION
Adds a `hideIf` function, which works in the opposite way as the existing `showIf` function. Sometimes it is easier to read code when it is phrased as `hideIf` as contrary to `showIf`.