### PR TITLE
PAR-1878: Prevents event from selecting checkbox from bubbling up

### DIFF
--- a/explorer/src/Stories/MultiSelectDropdown.elm
+++ b/explorer/src/Stories/MultiSelectDropdown.elm
@@ -18,6 +18,7 @@ stories =
                     |> MultiSelectDropdown.withPlaceholder "Choose an option"
                     |> MultiSelectDropdown.withHasFocus model.customModel.hasMultiSelectDropdownFocus
                     |> MultiSelectDropdown.withRequirednessHint (Just (RequirednessHint.Mandatory .no))
+                    |> MultiSelectDropdown.withHintText (Just "Hint")
                     |> MultiSelectDropdown.withOptions
                         [ { name = "1", label = "Valg 1", isChecked = model.customModel.isChoice1, onCheck = \_ -> OnCheckChoice1 }
                         , { name = "2", label = "Valg 2", isChecked = model.customModel.isChoice2, onCheck = \_ -> OnCheckChoice2 }

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -31,18 +31,23 @@ import Css
         , cursor
         , display
         , displayFlex
+        , fitContent
         , flexDirection
         , fontSize
         , height
         , hover
         , inherit
+        , int
         , justifyContent
         , left
         , lineHeight
         , listStyle
         , marginBottom
+        , marginInlineEnd
+        , marginInlineStart
         , maxHeight
         , maxWidth
+        , minWidth
         , none
         , overflowY
         , padding
@@ -60,12 +65,13 @@ import Css
         , spaceBetween
         , top
         , transparent
-        , width
+        , zIndex
         )
 import Html.Styled as Html exposing (Attribute, Html)
-import Html.Styled.Attributes exposing (class, css, name, tabindex)
+import Html.Styled.Attributes exposing (css, name, tabindex)
 import Html.Styled.Events as Events
 import Json.Decode as Decode
+import Maybe.Extra as Maybe
 import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Util.Hint as Hint
 import Nordea.Components.Util.Label as Label
@@ -105,11 +111,23 @@ init { onFocus } =
 view : List (Attribute msg) -> MultiSelectDropdown msg -> Html msg
 view attrs dropdown =
     let
+        isLabel =
+            not (String.isEmpty dropdown.label)
+
+        isRequirednessHint =
+            Maybe.isJust dropdown.requirednessHint
+
         viewSelectItems =
             let
                 viewOption option =
                     Html.li
-                        [ Events.custom "click" (Decode.succeed { message = option.onCheck (not option.isChecked), stopPropagation = True, preventDefault = True })
+                        [ Events.custom "click"
+                            (Decode.succeed
+                                { message = option.onCheck (not option.isChecked)
+                                , stopPropagation = True
+                                , preventDefault = True
+                                }
+                            )
                         , css
                             [ maxWidth (pct 100)
                             , cursor pointer
@@ -160,6 +178,9 @@ view attrs dropdown =
                         , maxHeight (rem 16.75)
                         , dropdownStyles
                         , listStyle none
+                        , Css.property "margin-block-start" "0"
+                        , Css.property "margin-block-end" "0"
+                        , Css.property "padding-inline-start" "0"
                         ]
                     ]
                     (dropdown.options |> List.map viewOption)
@@ -169,7 +190,20 @@ view attrs dropdown =
         ([ Events.on "focusout" (Decode.succeed (dropdown.onFocus False))
          , Events.onClick (dropdown.onFocus (not dropdown.hasFocus))
          , tabindex 0
-         , css [ displayFlex, flexDirection column ]
+         , css
+            [ minWidth fitContent
+            , zIndex (int 1)
+            , displayFlex
+            , flexDirection column
+            , marginInlineStart (rem 0)
+            , marginInlineEnd (rem 0)
+            , Css.property "padding-block-start" "0"
+            , Css.property "padding-block-end" "0"
+            , Css.property "padding-inline-start" "0"
+            , Css.property "padding-inline-end" "0"
+            , Css.property "border" "none"
+            , Css.property "min-inline-size" "min-content"
+            ]
          ]
             ++ attrs
         )
@@ -177,20 +211,15 @@ view attrs dropdown =
             [ Label.init { label = dropdown.label } |> Label.withAsLegend |> Label.view []
             , dropdown.requirednessHint |> Html.viewMaybe RequirednessHint.view
             ]
-        , Html.div
-            [ class "nordea-select"
-            , css [ position relative ]
-            ]
+            |> Html.showIf (isLabel || isRequirednessHint)
+        , Html.div [ css [ position relative ] ]
             [ Html.select
                 [ css [ display none ] ]
                 (dropdown.options |> List.map (\option -> Html.option [ name option.name ] [ Html.text option.label ]))
             , Html.div
-                [ class "select-selected"
-                , css
-                    [ height (rem 3)
-                    , width (pct 100)
-                    , backgroundColor transparent
-                    , padding4 (rem 0.5) (rem 1) (rem 0.5) (rem 1)
+                [ css
+                    [ backgroundColor transparent
+                    , padding4 (rem 0.5) (rem 0.75) (rem 0.5) (rem 0.75)
                     , border3 (rem 0.0625) solid Colors.grayMedium
                     , if dropdown.hasFocus then
                         borderRadius4 (rem 0.25) (rem 0.25) (rem 0.0) (rem 0.0)

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -42,9 +42,8 @@ import Css
         , left
         , lineHeight
         , listStyle
+        , margin
         , marginBottom
-        , marginInlineEnd
-        , marginInlineStart
         , maxHeight
         , maxWidth
         , minWidth
@@ -178,9 +177,8 @@ view attrs dropdown =
                         , maxHeight (rem 16.75)
                         , dropdownStyles
                         , listStyle none
-                        , Css.property "margin-block-start" "0"
-                        , Css.property "margin-block-end" "0"
-                        , Css.property "padding-inline-start" "0"
+                        , margin (rem 0)
+                        , padding (rem 0)
                         ]
                     ]
                     (dropdown.options |> List.map viewOption)
@@ -195,14 +193,10 @@ view attrs dropdown =
             , zIndex (int 1)
             , displayFlex
             , flexDirection column
-            , marginInlineStart (rem 0)
-            , marginInlineEnd (rem 0)
-            , Css.property "padding-block-start" "0"
-            , Css.property "padding-block-end" "0"
-            , Css.property "padding-inline-start" "0"
-            , Css.property "padding-inline-end" "0"
+            , margin (rem 0)
+            , padding (rem 0)
             , Css.property "border" "none"
-            , Css.property "min-inline-size" "min-content"
+            , position relative
             ]
          ]
             ++ attrs
@@ -212,35 +206,32 @@ view attrs dropdown =
             , dropdown.requirednessHint |> Html.viewMaybe RequirednessHint.view
             ]
             |> Html.showIf (isLabel || isRequirednessHint)
-        , Html.div [ css [ position relative ] ]
-            [ Html.select
-                [ css [ display none ] ]
-                (dropdown.options |> List.map (\option -> Html.option [ name option.name ] [ Html.text option.label ]))
-            , Html.div
-                [ css
-                    [ backgroundColor transparent
-                    , padding4 (rem 0.5) (rem 0.75) (rem 0.5) (rem 0.75)
-                    , border3 (rem 0.0625) solid Colors.grayMedium
-                    , if dropdown.hasFocus then
-                        borderRadius4 (rem 0.25) (rem 0.25) (rem 0.0) (rem 0.0)
+        , Html.select [ css [ display none ] ]
+            (dropdown.options |> List.map (\option -> Html.option [ name option.name ] [ Html.text option.label ]))
+        , Html.div
+            [ css
+                [ backgroundColor transparent
+                , padding4 (rem 0.5) (rem 0.75) (rem 0.5) (rem 0.75)
+                , border3 (rem 0.0625) solid Colors.grayMedium
+                , if dropdown.hasFocus then
+                    borderRadius4 (rem 0.25) (rem 0.25) (rem 0.0) (rem 0.0)
 
-                      else
-                        borderRadius4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0.25)
-                    , fontSize (rem 1.0)
-                    , lineHeight (rem 1.4)
-                    , color inherit
-                    , cursor pointer
-                    , displayFlex
-                    , alignItems center
-                    , justifyContent spaceBetween
-                    , Css.property "appearance" "none"
-                    ]
+                  else
+                    borderRadius4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0.25)
+                , fontSize (rem 1.0)
+                , lineHeight (rem 1.4)
+                , color inherit
+                , cursor pointer
+                , displayFlex
+                , alignItems center
+                , justifyContent spaceBetween
+                , Css.property "appearance" "none"
                 ]
-                [ Html.text dropdown.placeholder
-                , Icon.chevronDownFilled [ css [ height (rem 1.5) ] ]
-                ]
-            , viewSelectItems
             ]
+            [ Html.text dropdown.placeholder
+            , Icon.chevronDownFilled [ css [ height (rem 1.5) ] ]
+            ]
+        , viewSelectItems
         , dropdown.hint |> Html.viewMaybe (\hint -> Hint.init { text = hint } |> Hint.view)
         ]
 

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -109,7 +109,7 @@ view attrs dropdown =
             let
                 viewOption option =
                     Html.li
-                        [ Events.onClick (option.onCheck (not option.isChecked))
+                        [ Events.custom "click" (Decode.succeed { message = option.onCheck (not option.isChecked), stopPropagation = True, preventDefault = True })
                         , css
                             [ maxWidth (pct 100)
                             , cursor pointer
@@ -167,7 +167,7 @@ view attrs dropdown =
     in
     Html.fieldset
         ([ Events.on "focusout" (Decode.succeed (dropdown.onFocus False))
-         , Events.on "focusin" (Decode.succeed (dropdown.onFocus True))
+         , Events.onClick (dropdown.onFocus (not dropdown.hasFocus))
          , tabindex 0
          , css [ displayFlex, flexDirection column ]
          ]


### PR DESCRIPTION
### What was implemented? ✨🌈
- Removed default styling from `fieldset` and `ul` html elements. Default styling were not visible here for some reason. Could be css files added by explorer library? 
- Also prevents event from bubbling up when selecting an option in the dropdown