### PR TITLE
NumberInput formatter not works for typing decimal

### DIFF
--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -126,7 +126,7 @@ view attributes (NumberInput config) =
 getAttributes : Config msg -> List (Attribute msg)
 getAttributes config =
     let
-        format: String -> String
+        format : String -> String
         format value =
             if String.endsWith "." value || String.endsWith "," value then
                 value

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -127,8 +127,8 @@ getAttributes : Config msg -> List (Attribute msg)
 getAttributes config =
     let
         format value =
-            if value == "" then
-                ""
+            if String.endsWith "." value || String.endsWith "," value then
+                value
 
             else
                 Maybe.map2 (\formatter val -> val |> formatter)

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -126,6 +126,7 @@ view attributes (NumberInput config) =
 getAttributes : Config msg -> List (Attribute msg)
 getAttributes config =
     let
+        format: String -> String
         format value =
             if String.endsWith "." value || String.endsWith "," value then
                 value


### PR DESCRIPTION
The formatter of NumberInput component prevents users from typing decimal because the formatter would format unfinished number typing.

e.g. when users try to type "123.45", before finish typing, the formatter would format "123." to "123". Which make it not possible to type decimal numbers.