### PR TITLE
Extra small table variant

### DIFF
--- a/explorer/src/Stories/Table.elm
+++ b/explorer/src/Stories/Table.elm
@@ -113,13 +113,17 @@ stories =
         , ( "Extra Small"
           , \_ ->
                 Table.view [ css [ width (rem 60) ] ]
-                    [ Table.theadWithVariant Table.ExtraSmall []
+                    [ Table.theadWithVariant Table.ExtraSmall
+                        []
                         [ Table.tr [] (List.repeat 5 (Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]))
                         ]
-                    , Table.tbodyWithVariant Table.ExtraSmall []
-                        (List.repeat 5 (Table.tr []
-                            (List.repeat 5 (Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]))
-                        ))
+                    , Table.tbodyWithVariant Table.ExtraSmall
+                        []
+                        (List.repeat 5
+                            (Table.tr []
+                                (List.repeat 5 (Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]))
+                            )
+                        )
                     ]
           , {}
           )

--- a/explorer/src/Stories/Table.elm
+++ b/explorer/src/Stories/Table.elm
@@ -110,4 +110,19 @@ stories =
                     ]
           , {}
           )
+        , ( "Extra Small"
+          , \_ ->
+                Table.view [ css [ width (rem 60) ] ]
+                    [ Table.theadWithVariant []
+                        [ Table.tr [] (List.repeat 5 (Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]))
+                        ]
+                        Table.ExtraSmall
+                    , Table.tbodyWithVariant []
+                        (List.repeat 5 (Table.tr []
+                            (List.repeat 5 (Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]))
+                        ))
+                        Table.ExtraSmall
+                    ]
+          , {}
+          )
         ]

--- a/explorer/src/Stories/Table.elm
+++ b/explorer/src/Stories/Table.elm
@@ -113,15 +113,13 @@ stories =
         , ( "Extra Small"
           , \_ ->
                 Table.view [ css [ width (rem 60) ] ]
-                    [ Table.theadWithVariant []
+                    [ Table.theadWithVariant Table.ExtraSmall []
                         [ Table.tr [] (List.repeat 5 (Table.th [ css [ flex (int 1) ] ] [ Html.text "Text" ]))
                         ]
-                        Table.ExtraSmall
-                    , Table.tbodyWithVariant []
+                    , Table.tbodyWithVariant Table.ExtraSmall []
                         (List.repeat 5 (Table.tr []
                             (List.repeat 5 (Table.td [ css [ flex (int 1), textAlign center ] ] [ Html.text "Text" ]))
                         ))
-                        Table.ExtraSmall
                     ]
           , {}
           )

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -7,6 +7,9 @@ module Nordea.Components.Table exposing
     , theadSmall
     , tr
     , view
+    , Variant
+    , theadWithVariant
+    , tbodyWithVariant
     )
 
 import Css

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -73,7 +73,7 @@ theadWithVariant attrs children variant =
                     rem 3.5
 
                 ExtraSmall ->
-                    rem 1.5
+                    rem 2.5
     in
     Html.thead
         (css
@@ -136,7 +136,7 @@ tbodyWithVariant attrs children variant =
                     rem 4.5
 
                 ExtraSmall ->
-                    rem 2.5
+                    rem 1.5
     in
     Html.tbody
         (css

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -47,6 +47,7 @@ import Nordea.Themes as Themes
 type Variant
     = Small
     | Standard
+    | ExtraSmall
 
 
 view : List (Attribute msg) -> List (Html msg) -> Html msg
@@ -70,6 +71,9 @@ theadWithVariant attrs children variant =
 
                 Standard ->
                     rem 3.5
+
+                ExtraSmall ->
+                    rem 1.5
     in
     Html.thead
         (css
@@ -130,6 +134,9 @@ tbodyWithVariant attrs children variant =
 
                 Standard ->
                     rem 4.5
+
+                ExtraSmall ->
+                    rem 2.5
     in
     Html.tbody
         (css

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -7,7 +7,7 @@ module Nordea.Components.Table exposing
     , theadSmall
     , tr
     , view
-    , Variant
+    , Variant(..)
     , theadWithVariant
     , tbodyWithVariant
     )

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -61,8 +61,8 @@ view attrs children =
 
 {-| Groups the header content in a table
 -}
-theadWithVariant : List (Attribute msg) -> List (Html msg) -> Variant -> Html msg
-theadWithVariant attrs children variant =
+theadWithVariant : Variant -> List (Attribute msg) -> List (Html msg) -> Html msg
+theadWithVariant variant attrs =
     let
         headHeight =
             case variant of
@@ -82,21 +82,20 @@ theadWithVariant attrs children variant =
             ]
             :: attrs
         )
-        children
 
 
 {-| Groups the header content in a table
 -}
 thead : List (Attribute msg) -> List (Html msg) -> Html msg
 thead attrs children =
-    theadWithVariant attrs children Standard
+    theadWithVariant Standard attrs children
 
 
 {-| Groups the header content in a smaller table
 -}
 theadSmall : List (Attribute msg) -> List (Html msg) -> Html msg
 theadSmall attrs children =
-    theadWithVariant attrs children Small
+    theadWithVariant Small attrs children
 
 
 {-| Defines a row in a table
@@ -124,8 +123,8 @@ th attrs children =
 
 {-| Groups the body content in a table
 -}
-tbodyWithVariant : List (Attribute msg) -> List (Html msg) -> Variant -> Html msg
-tbodyWithVariant attrs children variant =
+tbodyWithVariant : Variant -> List (Attribute msg) -> List (Html msg) -> Html msg
+tbodyWithVariant variant attrs =
     let
         trHeight =
             case variant of
@@ -152,21 +151,20 @@ tbodyWithVariant attrs children variant =
             ]
             :: attrs
         )
-        children
 
 
 {-| Groups the body content in a table
 -}
 tbody : List (Attribute msg) -> List (Html msg) -> Html msg
 tbody attrs children =
-    tbodyWithVariant attrs children Standard
+    tbodyWithVariant Standard attrs children
 
 
 {-| Groups the body content in a smaller table
 -}
 tbodySmall : List (Attribute msg) -> List (Html msg) -> Html msg
 tbodySmall attrs children =
-    tbodyWithVariant attrs children Small
+    tbodyWithVariant Small attrs children
 
 
 {-| Defines a cell in a table

--- a/src/Nordea/Components/Table.elm
+++ b/src/Nordea/Components/Table.elm
@@ -1,15 +1,15 @@
 module Nordea.Components.Table exposing
-    ( tbody
+    ( Variant(..)
+    , tbody
     , tbodySmall
+    , tbodyWithVariant
     , td
     , th
     , thead
     , theadSmall
+    , theadWithVariant
     , tr
     , view
-    , Variant(..)
-    , theadWithVariant
-    , tbodyWithVariant
     )
 
 import Css


### PR DESCRIPTION
## Screenshot 📷 
![bilde](https://user-images.githubusercontent.com/26062822/212893126-6c31e35e-284a-4eae-a82e-e00fadb5dc23.png)

## Features ✨ 
1. Adds a smaller table variant (FinansFront ❤️)
2. Exposes the internal variant type instead of creating `tbodyExtraSmall` and `theadExtraSmall` functions
3. Explorer example
4. Changes the `t(head|body)WithVariant` function API to take `Variant` first, a little bit cleaner IMO 

## Discussion points ⚔️ 

Should we remove the `t(head|body)Small` functions? They make writing tables a little bit terser, but I would argue that fidgeting with the `table`, `thead` and `tbody` elements in the HTML is very "low level" and will probably be abstracted away anyway by to some nice function like `myNiceTableFunc: List MyCoolDomainModelType -> Html msg`. This _will_ break backwards compatibility though so is it worth it to have a "neater" `Table` component API? 

@vetlesolgaard would appreciate you and/or your team's input on this 😊 🙏 