### PR TITLE
Clamp progress 0 100 to fix weird visual bugs

### DIFF
--- a/src/Nordea/Components/ProgressBar.elm
+++ b/src/Nordea/Components/ProgressBar.elm
@@ -86,6 +86,7 @@ view attrs config =
 
         progress =
             floor config.progress
+                |> clamp 0 100
 
         maxProgress =
             max 100 progress


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/21218279/223428991-8c9d72c8-6a61-4023-ad72-49f9d1016322.png)

![image](https://user-images.githubusercontent.com/21218279/223429022-ac771a60-3919-4410-b084-def5e7de378a.png)


If you set progress to < 0 and > 100, you get weird (but kinda makes sense) results as shown above.
this clamps progress between 0 and 100, so this never happens.

progress < 0 and progress > 100 is of course an implementation error in the apps, but
I guess it can be nice to just fix it here also, so it looks a bit more sensible to the users

Open for suggestion/just closing