### PR TITLE
Add SkeletonLoader component

### DIFF
--- a/explorer/src/Explorer.elm
+++ b/explorer/src/Explorer.elm
@@ -34,6 +34,7 @@ import Stories.ProgressBar as ProgressBar
 import Stories.ProgressBarStepper as ProgressBarStepper
 import Stories.RadioButton as RadioButton
 import Stories.Range as Range
+import Stories.SkeletonLoader as SkeletonLoader
 import Stories.Slider as Slider
 import Stories.Spinner as Spinner
 import Stories.Status as Status
@@ -114,6 +115,7 @@ main =
                 , ProgressBarStepper.stories
                 , RadioButton.stories
                 , Range.stories
+                , SkeletonLoader.stories
                 , Slider.stories
                 , Spinner.stories
                 , Status.stories

--- a/explorer/src/Stories/SkeletonLoader.elm
+++ b/explorer/src/Stories/SkeletonLoader.elm
@@ -23,7 +23,7 @@ stories =
           , \_ -> SkeletonLoader.view [css [ width (pct 50), height (rem 2.5), borderRadius (rem 0.25) ]]
           , {}
           )
-          , ( "Button"
+        , ( "Button"
           , \_ -> SkeletonLoader.view [ css [borderRadius (rem 2), width (rem 6), height (rem 2.5)] ]
           , {}
           )

--- a/explorer/src/Stories/SkeletonLoader.elm
+++ b/explorer/src/Stories/SkeletonLoader.elm
@@ -1,15 +1,15 @@
 module Stories.SkeletonLoader exposing (stories)
 
 import Config exposing (Config, Msg(..))
-import Css exposing (rem, width)
-import Html.Styled.Attributes exposing (css)
 import Css
     exposing
-        ( rem
+        ( borderRadius
         , height
         , pct
+        , rem
         , width
-        , borderRadius)
+        )
+import Html.Styled.Attributes exposing (css)
 import Nordea.Components.SkeletonLoader as SkeletonLoader
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -20,11 +20,11 @@ stories =
     styledStoriesOf
         "SkeletonLoader"
         [ ( "Default"
-          , \_ -> SkeletonLoader.view [css [ width (pct 50), height (rem 2.5), borderRadius (rem 0.25) ]]
+          , \_ -> SkeletonLoader.view [ css [ width (pct 50), height (rem 2.5), borderRadius (rem 0.25) ] ]
           , {}
           )
         , ( "Button"
-          , \_ -> SkeletonLoader.view [ css [borderRadius (rem 2), width (rem 6), height (rem 2.5)] ]
+          , \_ -> SkeletonLoader.view [ css [ borderRadius (rem 2), width (rem 6), height (rem 2.5) ] ]
           , {}
           )
         ]

--- a/explorer/src/Stories/SkeletonLoader.elm
+++ b/explorer/src/Stories/SkeletonLoader.elm
@@ -1,0 +1,30 @@
+module Stories.SkeletonLoader exposing (stories)
+
+import Config exposing (Config, Msg(..))
+import Css exposing (rem, width)
+import Html.Styled.Attributes exposing (css)
+import Css
+    exposing
+        ( rem
+        , height
+        , pct
+        , width
+        , borderRadius)
+import Nordea.Components.SkeletonLoader as SkeletonLoader
+import UIExplorer exposing (UI)
+import UIExplorer.Styled exposing (styledStoriesOf)
+
+
+stories : UI Config Msg {}
+stories =
+    styledStoriesOf
+        "SkeletonLoader"
+        [ ( "Default"
+          , \_ -> SkeletonLoader.view [css [ width (pct 50), height (rem 2.5), borderRadius (rem 0.25) ]]
+          , {}
+          )
+          , ( "Button"
+          , \_ -> SkeletonLoader.view [ css [borderRadius (rem 2), width (rem 6), height (rem 2.5)] ]
+          , {}
+          )
+        ]

--- a/src/Nordea/Components/SkeletonLoader.elm
+++ b/src/Nordea/Components/SkeletonLoader.elm
@@ -1,0 +1,42 @@
+module Nordea.Components.SkeletonLoader exposing (view)
+
+import Css
+    exposing
+        ( animationDuration
+        , animationName
+        , ms
+        )
+import Css.Animations exposing (keyframes)
+import Html.Styled as Html
+    exposing
+        ( Attribute
+        , Html
+        )
+import Html.Styled.Attributes exposing (css)
+
+
+view : List (Attribute msg) -> Html msg
+view attrs =
+    Html.div
+        (css
+            [ skeletonLoading
+            ]
+            :: attrs
+        )
+        []
+
+
+skeletonLoading : Css.Style
+skeletonLoading =
+    Css.batch
+        [ Css.property "background" "linear-gradient(90deg, rgba(201, 199, 199, 0.25) 37.5%, rgba(139, 138, 141, 0.25) 50%, rgba(201, 199, 199, 0.25) 62.5%)"
+        , Css.property "background-size" "200% 200%"
+        , animationDuration (ms 1400)
+        , Css.property "animation-timing-function" "ease"
+        , Css.property "animation-iteration-count" "infinite"
+        , animationName <|
+            keyframes
+                [ ( 0, [ Css.Animations.property "background-position-x" "200%" ] )
+                , ( 100, [ Css.Animations.property "background-position-x" "0%" ] )
+                ]
+        ]

--- a/src/Nordea/Components/SkeletonLoader.elm
+++ b/src/Nordea/Components/SkeletonLoader.elm
@@ -12,16 +12,19 @@ import Html.Styled as Html
         ( Attribute
         , Html
         )
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Attrs exposing (css)
 
 
 view : List (Attribute msg) -> Html msg
 view attrs =
     Html.div
-        (css
+        ([ Attrs.attribute "aria-busy" "true"
+         , Attrs.attribute "aria-live" "polite"
+         , css
             [ skeletonLoading
             ]
-            :: attrs
+         ]
+            ++ attrs
         )
         []
 


### PR DESCRIPTION
Skeleton loader is already used in PH, so added here as a component. The component in itself is an empty div with styling, so shape and size specifications are passed as parameters. I added two examples to the UI Explorer for illustrations.

Screenshots:
<img width="735" alt="Screenshot 2023-03-17 at 9 16 33 AM" src="https://user-images.githubusercontent.com/63602600/225850082-d867e40f-c47d-4a51-a614-79855aa63c33.png">
<img width="222" alt="Screenshot 2023-03-17 at 9 16 52 AM" src="https://user-images.githubusercontent.com/63602600/225850147-260d962f-bb83-480c-9862-3e661760f2dc.png">
