### PR TITLE
Fix clipping of modal dialogs on narrow screens

### DIFF
--- a/explorer/src/Stories/Modal.elm
+++ b/explorer/src/Stories/Modal.elm
@@ -1,7 +1,7 @@
 module Stories.Modal exposing (..)
 
 import Config exposing (Msg(..))
-import Css exposing (rem, width)
+import Css exposing (..)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -44,6 +44,23 @@ stories =
                             |> Modal.view
                                 [ css [ width (rem 35) ] ]
                                 [ Html.text "Suggested width is 560px (35rem)" ]
+
+                      else
+                        Html.text ""
+                    ]
+          , {}
+          )
+        , ( "Responsive"
+          , \model ->
+                Html.div []
+                    [ Button.primary
+                        |> Button.view [ onClick ToggleModal ] [ Html.text "Show modal" ]
+                    , if model.customModel.isModalOpen then
+                        Modal.default ToggleModal
+                            |> Modal.withTitle "Title"
+                            |> Modal.view
+                                [ css [ maxWidth (rem 35), width (pct 100) ] ]
+                                [ Html.text "Max width is 560px (35rem)" ]
 
                       else
                         Html.text ""

--- a/src/Nordea/Components/Modal.elm
+++ b/src/Nordea/Components/Modal.elm
@@ -6,43 +6,7 @@ module Nordea.Components.Modal exposing
     , withTitle
     )
 
-import Css
-    exposing
-        ( alignItems
-        , auto
-        , backgroundColor
-        , borderBottom3
-        , borderRadius
-        , bottom
-        , center
-        , color
-        , column
-        , displayFlex
-        , fixed
-        , flexDirection
-        , hidden
-        , int
-        , justifyContent
-        , left
-        , margin
-        , marginLeft
-        , maxWidth
-        , minWidth
-        , none
-        , outline
-        , overflow
-        , padding
-        , padding3
-        , padding4
-        , pct
-        , position
-        , rem
-        , solid
-        , textAlign
-        , top
-        , width
-        , zIndex
-        )
+import Css exposing (..)
 import Css.Global as Global
 import Css.Media as Media
 import Html.Styled as Html exposing (Attribute, Html)

--- a/src/Nordea/Components/Modal.elm
+++ b/src/Nordea/Components/Modal.elm
@@ -40,6 +40,7 @@ import Css
         , solid
         , textAlign
         , top
+        , width
         , zIndex
         )
 import Css.Global as Global
@@ -129,7 +130,7 @@ view attrs children (Modal config) =
             , outline none
             , overflow auto
             , displayFlex
-            , minWidth (pct 100)
+            , width (pct 100)
             , justifyContent center
             , alignItems center
             , padding (rem 0)

--- a/src/Nordea/Components/Modal.elm
+++ b/src/Nordea/Components/Modal.elm
@@ -70,8 +70,6 @@ view attrs children (Modal config) =
                         , backgroundColor Colors.white
                         , displayFlex
                         , flexDirection column
-                        , minWidth (rem 18)
-                        , maxWidth (rem 60)
                         , margin auto
                         , Media.withMedia
                             [ Media.only Media.screen [ Media.minWidth (rem 47) ] ]

--- a/src/Nordea/Components/Modal.elm
+++ b/src/Nordea/Components/Modal.elm
@@ -94,7 +94,7 @@ view attrs children (Modal config) =
             , outline none
             , overflow auto
             , displayFlex
-            , width (pct 100)
+            , minWidth (pct 100)
             , justifyContent center
             , alignItems center
             , padding (rem 0)


### PR DESCRIPTION
At least ESign is affected. What makes this particularly bad is inability to close the dialog for example on a mobile device if close button and eXit icon are on the right.


<details><summary>Old behavior GIF</summary>

![clipped-modal](https://github.com/SGFinansAS/elm-components/assets/12462953/5cb7933f-9e5a-41e0-8646-7baf2bf9704d)

</details>

<details><summary>Fixed</summary>

![fixed-modal](https://github.com/SGFinansAS/elm-components/assets/12462953/deeafb36-0e79-4c0c-9703-abd49670dd94)

</details>