### PR TITLE
PAR-2347: Collapsible InformationDetails Card

### DIFF
--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -25,7 +25,6 @@ stories =
                     ]
                     [ InformationDetails.card
                         []
-                        (Just "Title")
                         [ InformationDetails.fullWidthElement []
                             [ InformationDetails.label [] [ Html.text "Full width" ]
                             , InformationDetails.value [] [ Html.text "Full width" ]
@@ -51,6 +50,7 @@ stories =
                             , InformationDetails.value [] [ Html.text "3" ]
                             ]
                         ]
+                        (Just "Title")
                         Nothing
                     ]
           , {}
@@ -65,7 +65,6 @@ stories =
                     ]
                     [ InformationDetails.card
                         []
-                        (Just "Title")
                         [ InformationDetails.fullWidthElement []
                             [ InformationDetails.label [] [ Html.text "Full width" ]
                             , InformationDetails.value [] [ Html.text "Full width" ]
@@ -91,6 +90,7 @@ stories =
                             , InformationDetails.value [] [ Html.text "3" ]
                             ]
                         ]
+                        (Just "Title")
                         (Just
                             { emphasisedText =
                                 Text.textLight

--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -2,7 +2,6 @@ module Stories.InformationDetails exposing (stories)
 
 import Config exposing (Config, Msg(..))
 import Css
-import Css.Transitions
 import Html.Styled as Html
 import Html.Styled.Attributes as Html exposing (css)
 import Nordea.Components.InformationDetails as InformationDetails
@@ -24,7 +23,9 @@ stories =
                         , Css.padding (Css.rem 2)
                         ]
                     ]
-                    [ InformationDetails.card []
+                    [ InformationDetails.card
+                        []
+                        (Just "Title")
                         [ InformationDetails.fullWidthElement []
                             [ InformationDetails.label [] [ Html.text "Full width" ]
                             , InformationDetails.value [] [ Html.text "Full width" ]
@@ -50,7 +51,7 @@ stories =
                             , InformationDetails.value [] [ Html.text "3" ]
                             ]
                         ]
-                        (Just "Title")
+                        Nothing
                     ]
           , {}
           )
@@ -62,48 +63,49 @@ stories =
                         , Css.padding (Css.rem 2)
                         ]
                     ]
-                    [ InformationDetails.collapsibleCard
-                        { attrs = []
-                        , title = "Title"
-                        , emphasisedText =
-                            Text.textLight
-                                |> Text.view
-                                    [ css
-                                        [ Css.paddingRight (Css.rem 0.75)
-                                        , Css.maxWidth (Css.rem 13.25)
-                                        , Css.textOverflow Css.ellipsis
-                                        , Css.overflow Css.hidden
-                                        ]
-                                    ]
-                                    [ Html.text "Emphasised Text" ]
-                        , isOpen = False
-                        , children =
-                            [ InformationDetails.fullWidthElement []
-                                [ InformationDetails.label [] [ Html.text "Full width" ]
-                                , InformationDetails.value [] [ Html.text "Full width" ]
-                                ]
-                            , InformationDetails.element []
-                                [ InformationDetails.label [] [ Html.text "Noe" ]
-                                , InformationDetails.value [] [ Html.text "Noe" ]
-                                ]
-                            , InformationDetails.element []
-                                [ InformationDetails.label [] [ Html.text "Noe mer" ]
-                                , InformationDetails.value [] [ Html.text "Noe mer" ]
-                                ]
-                            , InformationDetails.element []
-                                [ InformationDetails.label [] [ Html.text "Enda mer" ]
-                                , InformationDetails.value [] [ Html.text "Enda mer" ]
-                                ]
-                            , InformationDetails.fullWidthElement []
-                                [ InformationDetails.label []
-                                    [ Html.text "Label"
-                                    ]
-                                , InformationDetails.value [] [ Html.text "1" ]
-                                , InformationDetails.value [] [ Html.text "2" ]
-                                , InformationDetails.value [] [ Html.text "3" ]
-                                ]
+                    [ InformationDetails.card
+                        []
+                        (Just "Title")
+                        [ InformationDetails.fullWidthElement []
+                            [ InformationDetails.label [] [ Html.text "Full width" ]
+                            , InformationDetails.value [] [ Html.text "Full width" ]
                             ]
-                        }
+                        , InformationDetails.element []
+                            [ InformationDetails.label [] [ Html.text "Noe" ]
+                            , InformationDetails.value [] [ Html.text "Noe" ]
+                            ]
+                        , InformationDetails.element []
+                            [ InformationDetails.label [] [ Html.text "Noe mer" ]
+                            , InformationDetails.value [] [ Html.text "Noe mer" ]
+                            ]
+                        , InformationDetails.element []
+                            [ InformationDetails.label [] [ Html.text "Enda mer" ]
+                            , InformationDetails.value [] [ Html.text "Enda mer" ]
+                            ]
+                        , InformationDetails.fullWidthElement []
+                            [ InformationDetails.label []
+                                [ Html.text "Label"
+                                ]
+                            , InformationDetails.value [] [ Html.text "1" ]
+                            , InformationDetails.value [] [ Html.text "2" ]
+                            , InformationDetails.value [] [ Html.text "3" ]
+                            ]
+                        ]
+                        (Just
+                            { emphasisedText =
+                                Text.textLight
+                                    |> Text.view
+                                        [ css
+                                            [ Css.paddingRight (Css.rem 0.75)
+                                            , Css.maxWidth (Css.rem 13.25)
+                                            , Css.textOverflow Css.ellipsis
+                                            , Css.overflow Css.hidden
+                                            ]
+                                        ]
+                                        [ Html.text "Emphasised Text" ]
+                            , isOpen = False
+                            }
+                        )
                     ]
           , {}
           )

--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -2,9 +2,11 @@ module Stories.InformationDetails exposing (stories)
 
 import Config exposing (Config, Msg(..))
 import Css
+import Css.Transitions
 import Html.Styled as Html
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Html exposing (css)
 import Nordea.Components.InformationDetails as InformationDetails
+import Nordea.Components.Text as Text
 import Nordea.Resources.Colors as Colors
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -63,7 +65,20 @@ stories =
                     [ InformationDetails.collapsibleCard
                         { attrs = []
                         , title = "Title"
-                        , emphasisedText = "Emphasised Text"
+                        , emphasisedText =
+                            Text.textLight
+                                |> Text.view
+                                    [ css
+                                        [ Css.marginLeft Css.auto
+                                        , Css.paddingRight (Css.rem 0.75)
+                                        , Css.maxWidth (Css.rem 13.25)
+                                        , Css.textOverflow Css.ellipsis
+                                        , Css.overflow Css.hidden
+                                        , Css.Transitions.transition [ Css.Transitions.opacity3 400 0 Css.Transitions.ease ]
+                                        ]
+                                    , Html.class "accordion-closed-text"
+                                    ]
+                                    [ Html.text "Emphasised Text" ]
                         , isOpen = False
                         , children =
                             [ InformationDetails.fullWidthElement []

--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -52,7 +52,7 @@ stories =
                     ]
           , {}
           )
-        , ( "Collapsable"
+        , ( "Collapsible"
           , \_ ->
                 Html.div
                     [ css
@@ -60,7 +60,7 @@ stories =
                         , Css.padding (Css.rem 2)
                         ]
                     ]
-                    [ InformationDetails.collapsableCard
+                    [ InformationDetails.collapsibleCard
                         { attrs = []
                         , title = "Title"
                         , emphasisedText = "Emphasised Text"

--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -52,4 +52,47 @@ stories =
                     ]
           , {}
           )
+        , ( "Collapsable"
+          , \_ ->
+                Html.div
+                    [ css
+                        [ Css.backgroundColor Colors.lightGray
+                        , Css.padding (Css.rem 2)
+                        ]
+                    ]
+                    [ InformationDetails.collapsableCard
+                        { attrs = []
+                        , title = "Title"
+                        , emphasisedText = "Emphasised Text"
+                        , isOpen = False
+                        , children =
+                            [ InformationDetails.fullWidthElement []
+                                [ InformationDetails.label [] [ Html.text "Full width" ]
+                                , InformationDetails.value [] [ Html.text "Full width" ]
+                                ]
+                            , InformationDetails.element []
+                                [ InformationDetails.label [] [ Html.text "Noe" ]
+                                , InformationDetails.value [] [ Html.text "Noe" ]
+                                ]
+                            , InformationDetails.element []
+                                [ InformationDetails.label [] [ Html.text "Noe mer" ]
+                                , InformationDetails.value [] [ Html.text "Noe mer" ]
+                                ]
+                            , InformationDetails.element []
+                                [ InformationDetails.label [] [ Html.text "Enda mer" ]
+                                , InformationDetails.value [] [ Html.text "Enda mer" ]
+                                ]
+                            , InformationDetails.fullWidthElement []
+                                [ InformationDetails.label []
+                                    [ Html.text "Label"
+                                    ]
+                                , InformationDetails.value [] [ Html.text "1" ]
+                                , InformationDetails.value [] [ Html.text "2" ]
+                                , InformationDetails.value [] [ Html.text "3" ]
+                                ]
+                            ]
+                        }
+                    ]
+          , {}
+          )
         ]

--- a/explorer/src/Stories/InformationDetails.elm
+++ b/explorer/src/Stories/InformationDetails.elm
@@ -69,14 +69,11 @@ stories =
                             Text.textLight
                                 |> Text.view
                                     [ css
-                                        [ Css.marginLeft Css.auto
-                                        , Css.paddingRight (Css.rem 0.75)
+                                        [ Css.paddingRight (Css.rem 0.75)
                                         , Css.maxWidth (Css.rem 13.25)
                                         , Css.textOverflow Css.ellipsis
                                         , Css.overflow Css.hidden
-                                        , Css.Transitions.transition [ Css.Transitions.opacity3 400 0 Css.Transitions.ease ]
                                         ]
-                                    , Html.class "accordion-closed-text"
                                     ]
                                     [ Html.text "Emphasised Text" ]
                         , isOpen = False

--- a/src/Nordea/Components/AccordionMenu.elm
+++ b/src/Nordea/Components/AccordionMenu.elm
@@ -1,21 +1,6 @@
 module Nordea.Components.AccordionMenu exposing (header, view)
 
-import Css
-    exposing
-        ( alignItems
-        , auto
-        , center
-        , column
-        , display
-        , displayFlex
-        , flexDirection
-        , inlineBlock
-        , listStyle
-        , marginLeft
-        , none
-        , rem
-        , width
-        )
+import Css exposing (alignItems, auto, center, column, display, displayFlex, flexDirection, inlineBlock, listStyle, marginLeft, none, num, opacity, rem, width)
 import Css.Global exposing (children, class, typeSelector, withAttribute)
 import Html.Attributes.Extra exposing (empty)
 import Html.Styled as Html exposing (Attribute, Html)
@@ -45,7 +30,8 @@ view config attrs children_ =
                 [ typeSelector "summary"
                     [ listStyle none
                     , children
-                        [ class "accordion-open-icon" [ display inlineBlock ]
+                        [ class "accordion-closed-text" [ opacity (num 1) ]
+                        , class "accordion-open-icon" [ display inlineBlock ]
                         , class "accordion-closed-icon" [ display none ]
                         ]
                     ]
@@ -54,7 +40,8 @@ view config attrs children_ =
                 [ children
                     [ typeSelector "summary"
                         [ children
-                            [ class "accordion-closed-icon" [ display inlineBlock ]
+                            [ class "accordion-closed-text" [ opacity (num 0) ]
+                            , class "accordion-closed-icon" [ display inlineBlock ]
                             , class "accordion-open-icon" [ display none ]
                             ]
                         ]

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -203,11 +203,19 @@ withShadow (Card config) =
     Card { config | hasShadow = True }
 
 
-isCollapsible : Html msg -> Bool -> Card msg -> Card msg
-isCollapsible emphasisedText isOpen (Card config) =
-    Card
-        { config
-            | isCollapsible = True
-            , emphasisedText = Just emphasisedText
-            , isOpen = isOpen
-        }
+isCollapsible :
+    Maybe { emphasisedText : Html msg, isOpen : Bool }
+    -> Card msg
+    -> Card msg
+isCollapsible collapsibleProps (Card config) =
+    case collapsibleProps of
+        Nothing ->
+            Card config
+
+        Just props ->
+            Card
+                { config
+                    | isCollapsible = True
+                    , emphasisedText = Just props.emphasisedText
+                    , isOpen = props.isOpen
+                }

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -6,36 +6,74 @@ module Nordea.Components.Card exposing
     , init
     , title
     , view
+    , viewCollapsible
     , withShadow
     , withTitle
     )
 
 import Css
     exposing
-        ( auto
+        ( active
+        , alignItems
+        , alignSelf
+        , auto
         , backgroundColor
+        , before
         , border3
         , borderRadius
         , borderStyle
         , boxShadow4
+        , center
+        , color
         , column
+        , cursor
+        , default
         , displayFlex
+        , ellipsis
+        , flexBasis
         , flexDirection
+        , flexEnd
+        , flexGrow
         , height
+        , hidden
+        , hover
         , left
+        , listStyle
         , margin2
+        , marginBottom
+        , marginLeft
+        , marginRight
+        , marginTop
+        , maxWidth
+        , noWrap
         , none
+        , num
+        , opacity
+        , overflow
         , padding
+        , padding2
+        , paddingRight
+        , pct
+        , pointer
+        , pseudoClass
         , rem
+        , scale2
         , solid
         , textAlign
+        , textOverflow
+        , transform
+        , whiteSpace
         , width
         )
+import Css.Global as Css
+import Css.Transitions exposing (transition)
 import Html.Styled as Html exposing (Attribute, Html)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Html exposing (css)
+import Nordea.Components.AccordionMenu as AccordionMenu
 import Nordea.Components.Text as Text
 import Nordea.Html as Html exposing (styleIf, viewMaybe)
 import Nordea.Resources.Colors as Colors
+import Nordea.Resources.Icons as Icons
 
 
 type alias CardProperties =
@@ -74,6 +112,47 @@ view attrs children (Card config) =
         ((config.title |> viewMaybe (\title_ -> header [] [ title [] [ Html.text title_ ] ]))
             :: children
         )
+
+
+viewCollapsible : List (Attribute msg) -> Html msg -> Bool -> List (Html msg) -> Card msg -> Html msg
+viewCollapsible attrs emphasisedText isOpen children (Card config) =
+    AccordionMenu.view { isOpen = isOpen }
+        (css
+            [ cursor Css.default
+            , borderRadius (rem 0.5)
+            , padding (rem 1.5)
+            , backgroundColor Colors.white
+            ]
+            :: attrs
+        )
+        [ Html.summary
+            (css [ displayFlex, alignItems center, cursor pointer ] :: attrs)
+            [ config.title |> viewMaybe (\title_ -> Text.bodyTextHeavy |> Text.view [ css [] ] [ Html.text title_ ])
+            , emphasisedText
+            , Icons.chevronDown
+                [ Html.class "accordion-open-icon"
+                , css [ width (rem 1.25), color Colors.deepBlue ]
+                ]
+            , Icons.chevronUp
+                [ Html.class "accordion-closed-icon"
+                , css [ width (rem 1.25), color Colors.deepBlue ]
+                ]
+            ]
+        , Html.wrappedRow
+            [ css
+                [ marginTop (rem 2)
+                , marginBottom (rem -1.5)
+                , marginRight (rem -1)
+                , Css.children
+                    [ Css.everything
+                        [ marginBottom (rem 1.5)
+                        , marginRight (rem 1)
+                        ]
+                    ]
+                ]
+            ]
+            children
+        ]
 
 
 header : List (Attribute msg) -> List (Html msg) -> Html msg

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -36,11 +36,11 @@ import Nordea.Resources.Colors as Colors
 
 card :
     List (Attribute msg)
-    -> Maybe String
     -> List (Html msg)
+    -> Maybe String
     -> Maybe { emphasisedText : Html msg, isOpen : Bool }
     -> Html msg
-card attrs title children collapsibleProps =
+card attrs children title collapsibleProps =
     let
         withOptionalTitle =
             Maybe.map Card.withTitle title

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -1,6 +1,6 @@
 module Nordea.Components.InformationDetails exposing
     ( card
-    , collapsableCard
+    , collapsibleCard
     , element
     , fullWidthElement
     , label
@@ -82,7 +82,7 @@ card attrs children title =
             ]
 
 
-collapsableCard :
+collapsibleCard :
     { attrs : List (Attribute msg)
     , title : String
     , emphasisedText : String
@@ -90,7 +90,7 @@ collapsableCard :
     , children : List (Html msg)
     }
     -> Html msg
-collapsableCard { attrs, title, emphasisedText, isOpen, children } =
+collapsibleCard { attrs, title, emphasisedText, isOpen, children } =
     AccordionMenu.view { isOpen = isOpen }
         (css
             [ cursor Css.default

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -6,28 +6,14 @@ module Nordea.Components.InformationDetails exposing
     , value
     )
 
-import Css
-    exposing
-        ( color
-        , column
-        , displayFlex
-        , flexBasis
-        , flexDirection
-        , flexGrow
-        , flexWrap
-        , lineHeight
-        , marginBottom
-        , marginRight
-        , num
-        , pct
-        , rem
-        , wrap
-        )
+import Css exposing (auto, color, column, cursor, default, displayFlex, flexBasis, flexDirection, flexGrow, flexWrap, lineHeight, marginBottom, marginLeft, marginRight, marginTop, num, padding2, pct, pointer, rem, wrap)
 import Css.Global as Css exposing (children)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
+import Nordea.Components.AccordionMenu as AccordionMenu
 import Nordea.Components.Card as Card
 import Nordea.Components.Text as Text
+import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
 
 
@@ -57,6 +43,37 @@ card attrs children title =
                     ]
                 ]
                 children
+            ]
+
+
+cardCollapsable : List (Attribute msg) -> String -> List (Html msg) -> Html msg
+cardCollapsable attrs title children =
+    Card.init
+        |> Card.view
+            attrs
+            [ AccordionMenu.view
+                { isOpen = False }
+                (css [] :: attrs)
+                [ AccordionMenu.header [ css [ cursor pointer ] ]
+                    [ Text.bodyTextHeavy |> Text.view [ css [] ] [ Html.text title ]
+                    , value [ css [ marginLeft auto, cursor default, padding2 (rem 0) (rem 2) ] ]
+                        [ Html.text "test" ]
+                    ]
+                , Html.wrappedRow
+                    [ css
+                        [ marginTop (rem 2)
+                        , marginBottom (rem -1.5)
+                        , marginRight (rem -1)
+                        , Css.children
+                            [ Css.everything
+                                [ marginBottom (rem 1.5)
+                                , marginRight (rem 1)
+                                ]
+                            ]
+                        ]
+                    ]
+                    children
+                ]
             ]
 
 

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -85,61 +85,32 @@ card attrs children title =
 collapsibleCard :
     { attrs : List (Attribute msg)
     , title : String
-    , emphasisedText : String
-    , isOpen : Bool
+    , emphasisedText : Html msg
     , children : List (Html msg)
+    , isOpen : Bool
     }
     -> Html msg
-collapsibleCard { attrs, title, emphasisedText, isOpen, children } =
-    AccordionMenu.view { isOpen = isOpen }
-        (css
-            [ cursor Css.default
-            , borderRadius (rem 0.5)
-            , padding (rem 1.5)
-            , backgroundColor Colors.white
-            ]
-            :: attrs
-        )
-        [ Html.summary
-            (css [ displayFlex, alignItems center, cursor pointer ] :: attrs)
-            [ Text.bodyTextHeavy |> Text.view [ css [] ] [ Html.text title ]
-            , Text.textLight
-                |> Text.view
-                    [ css
-                        [ marginLeft auto
-                        , paddingRight (rem 0.75)
-                        , maxWidth (rem 13.25)
-                        , textOverflow ellipsis
-                        , overflow hidden
-                        , transition [ Css.Transitions.opacity3 400 0 Css.Transitions.ease ]
-                        ]
-                    , Html.class "accordion-closed-text"
-                    ]
-                    [ Html.text emphasisedText ]
-            , Icons.chevronDown
-                [ Html.class "accordion-open-icon"
-                , css [ width (rem 1.25), color Colors.deepBlue ]
-                ]
-            , Icons.chevronUp
-                [ Html.class "accordion-closed-icon"
-                , css [ width (rem 1.25), color Colors.deepBlue ]
-                ]
-            ]
-        , Html.wrappedRow
-            [ css
-                [ marginTop (rem 2)
-                , marginBottom (rem -1.5)
-                , marginRight (rem -1)
-                , Css.children
-                    [ Css.everything
-                        [ marginBottom (rem 1.5)
-                        , marginRight (rem 1)
+collapsibleCard { attrs, title, emphasisedText, children, isOpen } =
+    Card.init
+        |> Card.withTitle title
+        |> Card.viewCollapsible
+            attrs
+            emphasisedText
+            isOpen
+            [ Html.wrappedRow
+                [ css
+                    [ marginBottom (rem -1.5)
+                    , marginRight (rem -1)
+                    , Css.children
+                        [ Css.everything
+                            [ marginBottom (rem 1.5)
+                            , marginRight (rem 1)
+                            ]
                         ]
                     ]
                 ]
+                children
             ]
-            children
-        ]
 
 
 element : List (Attribute msg) -> List (Html msg) -> Html msg

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -9,48 +9,29 @@ module Nordea.Components.InformationDetails exposing
 
 import Css
     exposing
-        ( alignItems
-        , auto
-        , backgroundColor
-        , borderRadius
-        , center
-        , color
+        ( color
         , column
-        , cursor
         , displayFlex
-        , ellipsis
         , flexBasis
         , flexDirection
         , flexGrow
         , flexWrap
-        , hidden
         , lineHeight
         , marginBottom
-        , marginLeft
         , marginRight
         , marginTop
-        , maxWidth
         , num
-        , overflow
-        , padding
-        , paddingRight
         , pct
-        , pointer
         , rem
-        , textOverflow
-        , width
         , wrap
         )
 import Css.Global as Css exposing (children)
-import Css.Transitions exposing (transition)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Html exposing (css)
-import Nordea.Components.AccordionMenu as AccordionMenu
 import Nordea.Components.Card as Card
 import Nordea.Components.Text as Text
 import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
-import Nordea.Resources.Icons as Icons
 
 
 card : List (Attribute msg) -> List (Html msg) -> Maybe String -> Html msg
@@ -93,14 +74,16 @@ collapsibleCard :
 collapsibleCard { attrs, title, emphasisedText, children, isOpen } =
     Card.init
         |> Card.withTitle title
-        |> Card.viewCollapsible
+        |> Card.isCollapsible emphasisedText isOpen
+        |> Card.view
             attrs
-            emphasisedText
-            isOpen
-            [ Html.wrappedRow
+            [ Html.div
                 [ css
-                    [ marginBottom (rem -1.5)
+                    [ displayFlex
+                    , flexWrap wrap
+                    , marginBottom (rem -1.5)
                     , marginRight (rem -1)
+                    , marginTop (rem 1.5)
                     , Css.children
                         [ Css.everything
                             [ marginBottom (rem 1.5)

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -1,6 +1,5 @@
 module Nordea.Components.InformationDetails exposing
     ( card
-    , collapsibleCard
     , element
     , fullWidthElement
     , label
@@ -28,14 +27,20 @@ import Css
 import Css.Global as Css exposing (children)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Html exposing (css)
+import Maybe.Extra as Maybe
 import Nordea.Components.Card as Card
 import Nordea.Components.Text as Text
-import Nordea.Html as Html
+import Nordea.Html as Html exposing (styleIf)
 import Nordea.Resources.Colors as Colors
 
 
-card : List (Attribute msg) -> List (Html msg) -> Maybe String -> Html msg
-card attrs children title =
+card :
+    List (Attribute msg)
+    -> Maybe String
+    -> List (Html msg)
+    -> Maybe { emphasisedText : Html msg, isOpen : Bool }
+    -> Html msg
+card attrs title children collapsibleProps =
     let
         withOptionalTitle =
             Maybe.map Card.withTitle title
@@ -43,6 +48,7 @@ card attrs children title =
     in
     Card.init
         |> withOptionalTitle
+        |> Card.isCollapsible collapsibleProps
         |> Card.view
             attrs
             [ Html.div
@@ -51,42 +57,10 @@ card attrs children title =
                     , flexWrap wrap
                     , marginBottom (rem -2)
                     , marginRight (rem -1)
+                    , marginTop (rem 1.5) |> styleIf (collapsibleProps |> Maybe.isJust)
                     , Css.children
                         [ Css.everything
                             [ marginBottom (rem 2)
-                            , marginRight (rem 1)
-                            ]
-                        ]
-                    ]
-                ]
-                children
-            ]
-
-
-collapsibleCard :
-    { attrs : List (Attribute msg)
-    , title : String
-    , emphasisedText : Html msg
-    , children : List (Html msg)
-    , isOpen : Bool
-    }
-    -> Html msg
-collapsibleCard { attrs, title, emphasisedText, children, isOpen } =
-    Card.init
-        |> Card.withTitle title
-        |> Card.isCollapsible emphasisedText isOpen
-        |> Card.view
-            attrs
-            [ Html.div
-                [ css
-                    [ displayFlex
-                    , flexWrap wrap
-                    , marginBottom (rem -1.5)
-                    , marginRight (rem -1)
-                    , marginTop (rem 1.5)
-                    , Css.children
-                        [ Css.everything
-                            [ marginBottom (rem 1.5)
                             , marginRight (rem 1)
                             ]
                         ]

--- a/src/Nordea/Components/InformationDetails.elm
+++ b/src/Nordea/Components/InformationDetails.elm
@@ -1,20 +1,56 @@
 module Nordea.Components.InformationDetails exposing
     ( card
+    , collapsableCard
     , element
     , fullWidthElement
     , label
     , value
     )
 
-import Css exposing (auto, color, column, cursor, default, displayFlex, flexBasis, flexDirection, flexGrow, flexWrap, lineHeight, marginBottom, marginLeft, marginRight, marginTop, num, padding2, pct, pointer, rem, wrap)
+import Css
+    exposing
+        ( alignItems
+        , auto
+        , backgroundColor
+        , borderRadius
+        , center
+        , color
+        , column
+        , cursor
+        , displayFlex
+        , ellipsis
+        , flexBasis
+        , flexDirection
+        , flexGrow
+        , flexWrap
+        , hidden
+        , lineHeight
+        , marginBottom
+        , marginLeft
+        , marginRight
+        , marginTop
+        , maxWidth
+        , num
+        , overflow
+        , padding
+        , paddingRight
+        , pct
+        , pointer
+        , rem
+        , textOverflow
+        , width
+        , wrap
+        )
 import Css.Global as Css exposing (children)
+import Css.Transitions exposing (transition)
 import Html.Styled as Html exposing (Attribute, Html)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes as Html exposing (css)
 import Nordea.Components.AccordionMenu as AccordionMenu
 import Nordea.Components.Card as Card
 import Nordea.Components.Text as Text
 import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
+import Nordea.Resources.Icons as Icons
 
 
 card : List (Attribute msg) -> List (Html msg) -> Maybe String -> Html msg
@@ -46,35 +82,64 @@ card attrs children title =
             ]
 
 
-cardCollapsable : List (Attribute msg) -> String -> List (Html msg) -> Html msg
-cardCollapsable attrs title children =
-    Card.init
-        |> Card.view
-            attrs
-            [ AccordionMenu.view
-                { isOpen = False }
-                (css [] :: attrs)
-                [ AccordionMenu.header [ css [ cursor pointer ] ]
-                    [ Text.bodyTextHeavy |> Text.view [ css [] ] [ Html.text title ]
-                    , value [ css [ marginLeft auto, cursor default, padding2 (rem 0) (rem 2) ] ]
-                        [ Html.text "test" ]
-                    ]
-                , Html.wrappedRow
+collapsableCard :
+    { attrs : List (Attribute msg)
+    , title : String
+    , emphasisedText : String
+    , isOpen : Bool
+    , children : List (Html msg)
+    }
+    -> Html msg
+collapsableCard { attrs, title, emphasisedText, isOpen, children } =
+    AccordionMenu.view { isOpen = isOpen }
+        (css
+            [ cursor Css.default
+            , borderRadius (rem 0.5)
+            , padding (rem 1.5)
+            , backgroundColor Colors.white
+            ]
+            :: attrs
+        )
+        [ Html.summary
+            (css [ displayFlex, alignItems center, cursor pointer ] :: attrs)
+            [ Text.bodyTextHeavy |> Text.view [ css [] ] [ Html.text title ]
+            , Text.textLight
+                |> Text.view
                     [ css
-                        [ marginTop (rem 2)
-                        , marginBottom (rem -1.5)
-                        , marginRight (rem -1)
-                        , Css.children
-                            [ Css.everything
-                                [ marginBottom (rem 1.5)
-                                , marginRight (rem 1)
-                                ]
-                            ]
+                        [ marginLeft auto
+                        , paddingRight (rem 0.75)
+                        , maxWidth (rem 13.25)
+                        , textOverflow ellipsis
+                        , overflow hidden
+                        , transition [ Css.Transitions.opacity3 400 0 Css.Transitions.ease ]
                         ]
+                    , Html.class "accordion-closed-text"
                     ]
-                    children
+                    [ Html.text emphasisedText ]
+            , Icons.chevronDown
+                [ Html.class "accordion-open-icon"
+                , css [ width (rem 1.25), color Colors.deepBlue ]
+                ]
+            , Icons.chevronUp
+                [ Html.class "accordion-closed-icon"
+                , css [ width (rem 1.25), color Colors.deepBlue ]
                 ]
             ]
+        , Html.wrappedRow
+            [ css
+                [ marginTop (rem 2)
+                , marginBottom (rem -1.5)
+                , marginRight (rem -1)
+                , Css.children
+                    [ Css.everything
+                        [ marginBottom (rem 1.5)
+                        , marginRight (rem 1)
+                        ]
+                    ]
+                ]
+            ]
+            children
+        ]
 
 
 element : List (Attribute msg) -> List (Html msg) -> Html msg


### PR DESCRIPTION
Implemented collapsible Card in addition to the regular one. Collapsible card component is used in InformationDetails.  'emphasisedText' fades in and out when card is collapsed/uncollapsed.

![image](https://github.com/SGFinansAS/elm-components/assets/109804862/1c566d2a-6a25-41c0-8eca-40d6d3ac6169)
![image](https://github.com/SGFinansAS/elm-components/assets/109804862/258a7513-0715-4747-bc46-f95b8632fdbc)
