### PR TITLE
PAR-2720: Add small size for text and number input

### DIFF
--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -46,4 +46,11 @@ stories =
                     |> NumberInput.view [ disabled True ]
           , {}
           )
+        , ( "With small size"
+          , \_ ->
+                NumberInput.init "Text"
+                    |> NumberInput.withSmallSize
+                    |> NumberInput.view []
+          , {}
+          )
         ]

--- a/explorer/src/Stories/TextInput.elm
+++ b/explorer/src/Stories/TextInput.elm
@@ -82,4 +82,11 @@ stories =
                     |> TextInput.view []
           , {}
           )
+        , ( "With small size"
+          , \_ ->
+                TextInput.init "Text"
+                    |> TextInput.withSmallSize
+                    |> TextInput.view []
+          , {}
+          )
         ]

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -9,6 +9,7 @@ module Nordea.Components.NumberInput exposing
     , withOnBlur
     , withOnInput
     , withPlaceholder
+    , withSmallSize
     , withStep
     )
 
@@ -35,7 +36,13 @@ type alias Config msg =
     , showError : Bool
     , onBlur : Maybe msg
     , formatter : Maybe (Float -> String)
+    , size : Size
     }
+
+
+type Size
+    = Small
+    | Standard
 
 
 type NumberInput msg
@@ -54,6 +61,7 @@ init value =
         , showError = False
         , onBlur = Nothing
         , formatter = Nothing
+        , size = Standard
         }
 
 
@@ -95,6 +103,11 @@ withOnBlur msg (NumberInput config) =
 withFormatter : Maybe (Float -> String) -> NumberInput msg -> NumberInput msg
 withFormatter formatter (NumberInput config) =
     NumberInput { config | formatter = formatter }
+
+
+withSmallSize : NumberInput msg -> NumberInput msg
+withSmallSize (NumberInput config) =
+    NumberInput { config | size = Small }
 
 
 
@@ -152,14 +165,25 @@ getStyles config =
 
             else
                 Colors.mediumGray
+
+        sizeSpecificStyling =
+            case config.size of
+                Small ->
+                    [ fontSize (rem 0.75)
+                    , height (rem 1.5)
+                    , padding2 (rem 0.25) (rem 0.5)
+                    ]
+
+                Standard ->
+                    [ fontSize (rem 1)
+                    , height (rem 2.5)
+                    , padding2 (rem 0) (rem 0.75)
+                    ]
     in
-    [ fontSize (rem 1)
-    , height (rem 2.5)
-    , pseudoElement "-webkit-outer-spin-button" [ display none ]
+    [ pseudoElement "-webkit-outer-spin-button" [ display none ]
     , pseudoElement "-webkit-inner-spin-button" [ display none ]
     , property "-moz-appearance" "textfield"
     , textAlign right
-    , padding2 (rem 0) (rem 0.75)
     , borderRadius (rem 0.25)
     , border3 (rem 0.0625) solid borderColorStyle
     , boxSizing borderBox
@@ -170,3 +194,4 @@ getStyles config =
         , Themes.borderColor Colors.nordeaBlue
         ]
     ]
+        ++ sizeSpecificStyling

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -12,6 +12,7 @@ module Nordea.Components.TextInput exposing
     , withPattern
     , withPlaceholder
     , withSearchIcon
+    , withSmallSize
     )
 
 import Css
@@ -88,7 +89,13 @@ type alias Config msg =
     , onBlur : Maybe msg
     , onEnterPress : Maybe msg
     , currency : Maybe String
+    , size : Size
     }
+
+
+type Size
+    = Small
+    | Standard
 
 
 type TextInput msg
@@ -109,6 +116,7 @@ init value =
         , onBlur = Nothing
         , onEnterPress = Nothing
         , currency = Nothing
+        , size = Standard
         }
 
 
@@ -163,6 +171,11 @@ withClearInput (TextInput config) =
         { config
             | hasClearIcon = True
         }
+
+
+withSmallSize : TextInput msg -> TextInput msg
+withSmallSize (TextInput config) =
+    TextInput { config | size = Small }
 
 
 onEnterPress : msg -> Attribute msg
@@ -285,11 +298,22 @@ getStyles config =
 
             else
                 Colors.mediumGray
+
+        sizeSpecificStyling =
+            case config.size of
+                Small ->
+                    [ fontSize (rem 0.75)
+                    , height (rem 1.5)
+                    , padding2 (rem 0.25) (rem 0.5)
+                    ]
+
+                Standard ->
+                    [ fontSize (rem 1)
+                    , height (rem 2.5)
+                    , padding2 (rem 0) (rem 0.75)
+                    ]
     in
-    [ fontSize (rem 1)
-    , height (rem 2.5)
-    , padding2 (rem 0) (rem 0.75)
-    , borderRadius (rem 0.25)
+    [ borderRadius (rem 0.25)
     , border3 (rem 0.0625) solid borderColorStyle
     , boxSizing borderBox
     , width (pct 100)
@@ -305,3 +329,4 @@ getStyles config =
         , Themes.borderColor Colors.nordeaBlue
         ]
     ]
+        ++ sizeSpecificStyling


### PR DESCRIPTION
Add small size component so we can use in FF
https://www.figma.com/file/d7rS5EkSr1xMLupCrf0VTh/FinansFront-Sketches?type=design&node-id=90-5800&mode=design&t=pPkrv2KY7Nl6FUnk-0

![image](https://github.com/SGFinansAS/elm-components/assets/10939030/ac7d7102-4b01-41a5-a378-ed2f317e8047)
