### PR TITLE
Add small size dropdown component

### DIFF
--- a/explorer/src/Stories/Dropdown.elm
+++ b/explorer/src/Stories/Dropdown.elm
@@ -90,7 +90,7 @@ stories =
                     |> Dropdown.view []
           , {}
           )
-          , ( "Simple Small"
+        , ( "Simple Small"
           , \_ ->
                 Dropdown.simple
                     [ { value = Leasing, text = financingVariantToString Leasing }

--- a/explorer/src/Stories/Dropdown.elm
+++ b/explorer/src/Stories/Dropdown.elm
@@ -48,6 +48,21 @@ stories =
                     |> Dropdown.view []
           , {}
           )
+        , ( "Standard Small"
+          , \_ ->
+                Dropdown.init
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    ]
+                    financingVariantToString
+                    (\_ -> NoOp)
+                    |> Dropdown.withPlaceholder "Choose financing variant"
+                    |> Dropdown.withSmallSize
+                    |> Dropdown.view []
+          , {}
+          )
         , ( "Standard with error"
           , \_ ->
                 Dropdown.init
@@ -72,6 +87,20 @@ stories =
                     ]
                     financingVariantToString
                     (\_ -> NoOp)
+                    |> Dropdown.view []
+          , {}
+          )
+          , ( "Simple Small"
+          , \_ ->
+                Dropdown.simple
+                    [ { value = Leasing, text = financingVariantToString Leasing }
+                    , { value = Rent, text = financingVariantToString Rent }
+                    , { value = Loan, text = financingVariantToString Loan }
+                    , { value = HirePurchase, text = financingVariantToString HirePurchase }
+                    ]
+                    financingVariantToString
+                    (\_ -> NoOp)
+                    |> Dropdown.withSmallSize
                     |> Dropdown.view []
           , {}
           )

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -204,7 +204,7 @@ view attrs (Dropdown config) =
                         ]
 
                 ( Standard, SmallSize ) ->
-                    Icon.chevronDownFilled
+                    Icon.chevronDownFilledSmall
                         [ css
                             [ position absolute
                             , top (pct 50)
@@ -212,8 +212,6 @@ view attrs (Dropdown config) =
                             , right (rem 0.3125)
                             , pointerEvents none
                             , color Colors.coolGray
-                            , width (rem 1)
-                            , height (rem 1)
                             ]
                         ]
 

--- a/src/Nordea/Components/Dropdown.elm
+++ b/src/Nordea/Components/Dropdown.elm
@@ -10,6 +10,7 @@ module Nordea.Components.Dropdown exposing
     , withHasError
     , withPlaceholder
     , withSelectedValue
+    , withSmallSize
     )
 
 import Css
@@ -64,6 +65,11 @@ type Variant
     | Simple
 
 
+type Size
+    = StandardSize
+    | SmallSize
+
+
 type alias Option a =
     { value : a
     , text : String
@@ -92,6 +98,7 @@ type alias DropdownProperties a msg =
     , selectedValue : Maybe a
     , hasError : Bool
     , variant : Variant
+    , size : Size
     }
 
 
@@ -132,6 +139,7 @@ initWithOptionProperties options optionToString onInput =
         , selectedValue = Nothing
         , hasError = False
         , variant = Standard
+        , size = StandardSize
         }
 
 
@@ -182,8 +190,8 @@ view attrs (Dropdown config) =
             List.member (Attrs.disabled True) attrs
 
         iconChevron =
-            case config.variant of
-                Standard ->
+            case ( config.variant, config.size ) of
+                ( Standard, StandardSize ) ->
                     Icon.chevronDownFilled
                         [ css
                             [ position absolute
@@ -195,7 +203,21 @@ view attrs (Dropdown config) =
                             ]
                         ]
 
-                Simple ->
+                ( Standard, SmallSize ) ->
+                    Icon.chevronDownFilled
+                        [ css
+                            [ position absolute
+                            , top (pct 50)
+                            , transform (translateY (pct -50))
+                            , right (rem 0.3125)
+                            , pointerEvents none
+                            , color Colors.coolGray
+                            , width (rem 1)
+                            , height (rem 1)
+                            ]
+                        ]
+
+                ( Simple, _ ) ->
                     Icon.chevronDownBolded
                         [ css
                             [ position absolute
@@ -208,6 +230,14 @@ view attrs (Dropdown config) =
                             , color inherit
                             ]
                         ]
+
+        sizeSpecificStyling =
+            case config.size of
+                StandardSize ->
+                    [ height (rem 2.5), fontSize (rem 1), padding4 (rem 0.25) (rem 2.5) (rem 0.25) (rem 0.75), lineHeight (rem 1.4) ]
+
+                SmallSize ->
+                    [ height (rem 1.6), fontSize (rem 0.75), padding4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0.5), lineHeight (rem 1) ]
     in
     div
         (css [ position relative ] :: attrs)
@@ -215,35 +245,38 @@ view attrs (Dropdown config) =
             [ Events.on "change" decoder
             , Attrs.disabled isDisabled
             , css
-                [ height (rem 2.5)
-                , width (pct 100)
-                , property "appearance" "none"
-                , property "-moz-appearance" "none"
-                , property "-webkit-appearance" "none"
-                , backgroundColor transparent
-                , padding4 (rem 0.25) (rem 2.5) (rem 0.25) (rem 0.75)
-                , if config.variant /= Simple || config.hasError then
+                ([ width (pct 100)
+                 , property "appearance" "none"
+                 , property "-moz-appearance" "none"
+                 , property "-webkit-appearance" "none"
+                 , backgroundColor transparent
+                 , if config.variant /= Simple || config.hasError then
                     border3 (rem 0.0625) solid Colors.mediumGray
 
-                  else
+                   else
                     borderStyle none
-                , borderColor Colors.darkRed |> styleIf config.hasError
-                , borderRadius (rem 0.25)
-                , focus
+                 , borderColor Colors.darkRed |> styleIf config.hasError
+                 , borderRadius (rem 0.25)
+                 , focus
                     [ Css.property "box-shadow" ("0rem 0rem 0rem 0.0625rem " ++ Themes.colorVariable Colors.nordeaBlue)
                     , outline none
                     ]
-                , fontSize (rem 1.0)
-                , lineHeight (rem 1.4)
-                , color inherit
-                , withAttribute "disabled" [ color Colors.nordeaGray, backgroundColor Colors.coolGray ]
-                , cursor pointer
-                , textOverflow ellipsis |> styleIf (config.variant == Simple)
-                ]
+                 , color inherit
+                 , withAttribute "disabled" [ color Colors.nordeaGray, backgroundColor Colors.coolGray ]
+                 , cursor pointer
+                 , textOverflow ellipsis |> styleIf (config.variant == Simple)
+                 ]
+                    ++ sizeSpecificStyling
+                )
             ]
             (placeholder :: options)
         , iconChevron
         ]
+
+
+withSmallSize : Dropdown a msg -> Dropdown a msg
+withSmallSize (Dropdown config) =
+    Dropdown { config | size = SmallSize }
 
 
 withSelectedValue : Maybe a -> Dropdown a msg -> Dropdown a msg

--- a/src/Nordea/Resources/Icons.elm
+++ b/src/Nordea/Resources/Icons.elm
@@ -12,6 +12,7 @@ module Nordea.Resources.Icons exposing
     , chevronDown
     , chevronDownBolded
     , chevronDownFilled
+    , chevronDownFilledSmall
     , chevronLeft
     , chevronRight
     , chevronUp
@@ -85,23 +86,7 @@ import Html.Styled as Html exposing (Attribute, Html, div, styled)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Resources.Colors as Colors
 import Svg.Styled as Svg exposing (Svg, ellipse, svg)
-import Svg.Styled.Attributes as SvgAttrs
-    exposing
-        ( clipRule
-        , cx
-        , cy
-        , d
-        , fill
-        , fillRule
-        , height
-        , r
-        , rx
-        , ry
-        , stroke
-        , strokeWidth
-        , viewBox
-        , width
-        )
+import Svg.Styled.Attributes as SvgAttrs exposing (clipRule, cx, cy, d, fill, fillRule, height, r, rx, ry, stroke, strokeWidth, transform, viewBox, width)
 
 
 
@@ -219,6 +204,34 @@ chevronDownFilled attrs =
                 [ fillRule "evenodd"
                 , clipRule "evenodd"
                 , d "M9.46967 16.4697L15 10.9393L20.5303 16.4697L19.4697 17.5303L15 13.061L10.5303 17.5303L9.46967 16.4697Z"
+                , fill (Colors.toString Colors.darkestGray)
+                ]
+                []
+            ]
+        ]
+
+
+chevronDownFilledSmall : List (Attribute msg) -> Html msg
+chevronDownFilledSmall attrs =
+    iconContainer (css [ Css.width (rem 1) ] :: attrs)
+        [ svg
+            [ width "16"
+            , height "16"
+            , viewBox "0 0 16 16"
+            , fill "none"
+            ]
+            [ Svg.rect
+                [ width "16"
+                , height "16"
+                , rx "2"
+                , fill (Colors.toString Colors.coolGray)
+                ]
+                []
+            , Svg.path
+                [ fillRule "evenodd"
+                , clipRule "evenodd"
+                , transform "translate(2, 2)"
+                , d "M11.5303 4.53039L5.99994 10.0607L0.469613 4.53039L1.53027 3.46973L5.99994 7.93906L10.4696 3.46973L11.5303 4.53039Z"
                 , fill (Colors.toString Colors.darkestGray)
                 ]
                 []


### PR DESCRIPTION
Added a small size version of the dropdown component, to align with design decisions made for FinansFront.

Screenshot: 
<img width="258" alt="Screenshot 2023-11-27 at 1 43 41 PM" src="https://github.com/SGFinansAS/elm-components/assets/63602600/7a2189f9-c233-4c21-885b-65b7ca6cc500">

