### PR TITLE
PAR-2745: button with flatlink style does not show focus

### DIFF
--- a/src/Nordea/Components/Button.elm
+++ b/src/Nordea/Components/Button.elm
@@ -15,67 +15,7 @@ module Nordea.Components.Button exposing
     , withStyles
     )
 
-import Css
-    exposing
-        ( Style
-        , absolute
-        , alignItems
-        , auto
-        , backgroundColor
-        , batch
-        , border
-        , border3
-        , borderBox
-        , borderRadius
-        , borderStyle
-        , boxShadow4
-        , boxSizing
-        , center
-        , column
-        , cursor
-        , disabled
-        , displayFlex
-        , flex
-        , flexDirection
-        , focus
-        , fontFamilies
-        , fontSize
-        , fontWeight
-        , height
-        , hover
-        , int
-        , justifyContent
-        , left
-        , marginTop
-        , none
-        , num
-        , opacity
-        , outline
-        , padding
-        , padding2
-        , paddingRight
-        , pct
-        , pointer
-        , pointerEvents
-        , position
-        , relative
-        , rem
-        , right
-        , scale2
-        , solid
-        , start
-        , stretch
-        , textAlign
-        , textDecoration
-        , top
-        , transform
-        , transforms
-        , translateX
-        , translateY
-        , transparent
-        , underline
-        , width
-        )
+import Css exposing (Style, absolute, alignItems, auto, backgroundClip, backgroundColor, batch, border, border3, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxShadow4, boxSizing, center, column, contentBox, cursor, disabled, displayFlex, flex, flexDirection, focus, fontFamilies, fontSize, fontWeight, height, hover, int, justifyContent, left, marginTop, none, num, opacity, outline, outlineOffset, padding, padding2, paddingRight, pct, pointer, pointerEvents, position, relative, rem, right, scale2, solid, start, stretch, textAlign, textDecoration, top, transform, transforms, translateX, translateY, transparent, underline, width)
 import Css.Global exposing (children, descendants, everything, withClass)
 import Css.Transitions exposing (easeOut, transition)
 import Html.Styled as Html exposing (Attribute, Html)
@@ -356,12 +296,14 @@ variantStyle variant size =
             batch
                 [ textDecoration underline
                 , fontSize (rem 0.875)
-                , padding (rem 0)
                 , Themes.color Colors.deepBlue
                 , border (rem 0)
                 , backgroundColor transparent
                 , hover [ Themes.color Colors.nordeaBlue ]
-                , focus [ outline none ]
+                , focus
+                    [ outlineOffset (rem 0.5)
+                    , Css.property "outline" ("0.25rem solid " ++ Themes.colorVariable Colors.mediumBlue)
+                    ]
                 ]
 
         Circular ->


### PR DESCRIPTION
The design library has the focus
https://www.figma.com/file/tgFkTfmNZE0zwx44OeaohE/New-Design-System-anno-2023?type=design&node-id=399-25727&mode=design&t=iPshDl7nyMSjZ8HB-0


![image](https://github.com/SGFinansAS/elm-components/assets/34012758/2107ea47-bfd4-4436-a039-408aa0f132cd)

There are alternative ways of doing this

- outline
  - only text clickable at any point
  - the outline might overlay other elements

![outline](https://github.com/SGFinansAS/elm-components/assets/34012758/c014a98a-5688-47a9-9806-60b53bd975ad)


- padding
  - makes the empty space clickable along with text

![padding](https://github.com/SGFinansAS/elm-components/assets/34012758/f1a70ebe-7185-491e-852e-61d5e246e855)

- padding only on focus
  - the space is only clickable in the focus state 
  - it adds the padding only on focus so causes some movement in the layout   

![paddingonfocus](https://github.com/SGFinansAS/elm-components/assets/34012758/af68ef4b-8318-4b07-9708-5d30e4300beb)
