### PR TITLE
PAR-2742: new arrow placements for tooltip

### DIFF
--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -41,7 +41,7 @@ stories =
                         |> Tooltip.withPlacement Top
                         |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.view [] [ text "here here here here here here here here here" ]
                     ]
           , {}
           )
@@ -53,7 +53,7 @@ stories =
                         |> Tooltip.withPlacement TopRight
                         |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.view [] [ text "here here here here here here here here here" ]
                     ]
           , {}
           )
@@ -65,7 +65,7 @@ stories =
                         |> Tooltip.withPlacement TopLeft
                         |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.view [] [ text "here here here here here here here here here" ]
                     ]
           , {}
           )

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -1,6 +1,25 @@
 module Stories.Tooltip exposing (stories)
 
-import Css exposing (alignItems, center, displayFlex, height, listStyleType, margin, marginBottom, marginLeft, marginTop, none, overflowY, padding, position, relative, rem, scroll, width)
+import Css
+    exposing
+        ( alignItems
+        , center
+        , displayFlex
+        , height
+        , listStyleType
+        , margin
+        , marginBottom
+        , marginLeft
+        , marginTop
+        , none
+        , overflowY
+        , padding
+        , position
+        , relative
+        , rem
+        , scroll
+        , width
+        )
 import Html.Styled exposing (div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -16,10 +16,10 @@ import Css
         , scroll
         , width
         )
-import Html.Styled exposing (div, text)
+import Html.Styled exposing (div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card
-import Nordea.Components.Tooltip as Tooltip exposing (Placement(..), Visibility(..))
+import Nordea.Components.Tooltip as Tooltip exposing (ArrowPlacement(..), Placement(..), Visibility(..))
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -35,6 +35,30 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Top
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ text "here" ]
+                    ]
+          , {}
+          )
+        , ( "Top with arrow placed near corner"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement Top
+                        |> Tooltip.withArrowPlacement NearCorner
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ text "here" ]
+                    ]
+          , {}
+          )
+        , ( "Top with arrow placed near other corner"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement Top
+                        |> Tooltip.withArrowPlacement NearOtherCorner
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [] [ text "here" ]
                     ]
@@ -69,6 +93,23 @@ stories =
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ text "here" ]
+                    ]
+          , {}
+          )
+        , ( "Right with arrow placed near corner"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement Right
+                        |> Tooltip.withArrowPlacement NearCorner
+                        |> Tooltip.withContent
+                            (Tooltip.infoTooltip []
+                                [ ul []
+                                    [ li [] [ text "First" ], li [] [ text "Second" ], li [] [ text "Third" ], li [] [ text "Fourth" ] ]
+                                ]
+                            )
                         |> Tooltip.view [] [ text "here" ]
                     ]
           , {}

--- a/explorer/src/Stories/Tooltip.elm
+++ b/explorer/src/Stories/Tooltip.elm
@@ -1,25 +1,10 @@
 module Stories.Tooltip exposing (stories)
 
-import Css
-    exposing
-        ( alignItems
-        , center
-        , displayFlex
-        , height
-        , marginBottom
-        , marginLeft
-        , marginTop
-        , overflowY
-        , position
-        , relative
-        , rem
-        , scroll
-        , width
-        )
+import Css exposing (alignItems, center, displayFlex, height, listStyleType, margin, marginBottom, marginLeft, marginTop, none, overflowY, padding, position, relative, rem, scroll, width)
 import Html.Styled exposing (div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card
-import Nordea.Components.Tooltip as Tooltip exposing (ArrowPlacement(..), Placement(..), Visibility(..))
+import Nordea.Components.Tooltip as Tooltip exposing (Placement(..), Visibility(..))
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -35,30 +20,31 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Top
+                        |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
-        , ( "Top with arrow placed near corner"
+        , ( "TopRight"
           , \_ ->
                 div []
                     [ text "There is a tooltip "
                     , Tooltip.init
-                        |> Tooltip.withPlacement Top
-                        |> Tooltip.withArrowPlacement NearCorner
+                        |> Tooltip.withPlacement TopRight
+                        |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [] [ text "here" ]
                     ]
           , {}
           )
-        , ( "Top with arrow placed near other corner"
+        , ( "TopLeft"
           , \_ ->
                 div []
                     [ text "There is a tooltip "
                     , Tooltip.init
-                        |> Tooltip.withPlacement Top
-                        |> Tooltip.withArrowPlacement NearOtherCorner
+                        |> Tooltip.withPlacement TopLeft
+                        |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [] [ text "here" ]
                     ]
@@ -70,6 +56,31 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Bottom
+                        |> Tooltip.withVisibility Tooltip.Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ text "here" ]
+                    ]
+          , {}
+          )
+        , ( "BottomLeft"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement BottomLeft
+                        |> Tooltip.withVisibility Tooltip.Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ text "here" ]
+                    ]
+          , {}
+          )
+        , ( "BottomRight"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement BottomRight
+                        |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
                         |> Tooltip.view [] [ text "here" ]
                     ]
@@ -81,8 +92,33 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Left
+                        |> Tooltip.withVisibility Tooltip.Show
                         |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.view [] [ listOfSeveralItems ]
+                    ]
+          , {}
+          )
+        , ( "Left Top"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement LeftTop
+                        |> Tooltip.withVisibility Tooltip.Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ listOfSeveralItems ]
+                    ]
+          , {}
+          )
+        , ( "Left Bottom"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement LeftBottom
+                        |> Tooltip.withVisibility Tooltip.Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
+                        |> Tooltip.view [] [ listOfSeveralItems ]
                     ]
           , {}
           )
@@ -92,25 +128,33 @@ stories =
                     [ text "There is a tooltip "
                     , Tooltip.init
                         |> Tooltip.withPlacement Right
-                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text "This is a tooltip" ])
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.withVisibility Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text (lorem |> String.slice 0 100) ])
+                        |> Tooltip.view [] [ listOfSeveralItems ]
                     ]
           , {}
           )
-        , ( "Right with arrow placed near corner"
+        , ( "RightBottom"
           , \_ ->
                 div []
                     [ text "There is a tooltip "
                     , Tooltip.init
-                        |> Tooltip.withPlacement Right
-                        |> Tooltip.withArrowPlacement NearCorner
-                        |> Tooltip.withContent
-                            (Tooltip.infoTooltip []
-                                [ ul []
-                                    [ li [] [ text "First" ], li [] [ text "Second" ], li [] [ text "Third" ], li [] [ text "Fourth" ] ]
-                                ]
-                            )
-                        |> Tooltip.view [] [ text "here" ]
+                        |> Tooltip.withPlacement RightBottom
+                        |> Tooltip.withVisibility Tooltip.Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text (lorem |> String.slice 0 100) ])
+                        |> Tooltip.view [] [ listOfSeveralItems ]
+                    ]
+          , {}
+          )
+        , ( "Right Top"
+          , \_ ->
+                div []
+                    [ text "There is a tooltip "
+                    , Tooltip.init
+                        |> Tooltip.withPlacement RightTop
+                        |> Tooltip.withVisibility Show
+                        |> Tooltip.withContent (Tooltip.infoTooltip [] [ text (lorem |> String.slice 0 100) ])
+                        |> Tooltip.view [] [ listOfSeveralItems ]
                     ]
           , {}
           )
@@ -204,3 +248,13 @@ stories =
 
 lorem =
     "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+
+
+listOfSeveralItems =
+    ul [ css [ margin (rem 0), padding (rem 0), listStyleType none ] ]
+        [ li [] [ text "in" ]
+        , li [] [ text "any" ]
+        , li [] [ text "line" ]
+        , li [] [ text "of this" ]
+        , li [] [ text "multiline text" ]
+        ]

--- a/src/Nordea/Components/Coachmark.elm
+++ b/src/Nordea/Components/Coachmark.elm
@@ -78,7 +78,6 @@ type OptionalConfig
     | Placement Tooltip.Placement
     | ShowStep (Maybe Int)
     | ShowStepLegend Bool
-    | ArrowPlacement Tooltip.ArrowPlacement
 
 
 type alias RequiredProps msg =
@@ -101,7 +100,7 @@ type alias Step msg =
 view : RequiredProps msg -> List OptionalConfig -> List (Attribute msg) -> List (Step msg) -> Html msg
 view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
     let
-        { classesToHighlight, placement, showStep, showStepLegend, arrowPlacement } =
+        { classesToHighlight, placement, showStep, showStepLegend } =
             optionalConfig
                 |> List.foldl
                     (\e acc ->
@@ -117,15 +116,11 @@ view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
 
                             ShowStepLegend showStepLegend_ ->
                                 { acc | showStepLegend = showStepLegend_ }
-
-                            ArrowPlacement arrowPlacement_ ->
-                                { acc | arrowPlacement = arrowPlacement_ }
                     )
                     { classesToHighlight = Set.empty
                     , placement = Tooltip.Top
                     , showStep = Nothing
                     , showStepLegend = True
-                    , arrowPlacement = Tooltip.Center
                     }
 
         absoluteCenter scale_ =
@@ -200,7 +195,6 @@ view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
                 Tooltip.Show
             )
         |> Tooltip.withPlacement placement
-        |> Tooltip.withArrowPlacement arrowPlacement
         |> Tooltip.withContent
             (\arrow ->
                 Html.column

--- a/src/Nordea/Components/Coachmark.elm
+++ b/src/Nordea/Components/Coachmark.elm
@@ -66,7 +66,6 @@ import Nordea.Components.Button as Button
 import Nordea.Components.Text as Text
 import Nordea.Components.Tooltip as Tooltip
 import Nordea.Html as Html
-import Nordea.Html.Attributes as Attrs
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.I18N exposing (Translation)
 import Nordea.Resources.Icons as Icons
@@ -79,6 +78,7 @@ type OptionalConfig
     | Placement Tooltip.Placement
     | ShowStep (Maybe Int)
     | ShowStepLegend Bool
+    | ArrowPlacement Tooltip.ArrowPlacement
 
 
 type alias RequiredProps msg =
@@ -101,7 +101,7 @@ type alias Step msg =
 view : RequiredProps msg -> List OptionalConfig -> List (Attribute msg) -> List (Step msg) -> Html msg
 view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
     let
-        { classesToHighlight, placement, showStep, showStepLegend } =
+        { classesToHighlight, placement, showStep, showStepLegend, arrowPlacement } =
             optionalConfig
                 |> List.foldl
                     (\e acc ->
@@ -117,11 +117,15 @@ view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
 
                             ShowStepLegend showStepLegend_ ->
                                 { acc | showStepLegend = showStepLegend_ }
+
+                            ArrowPlacement arrowPlacement_ ->
+                                { acc | arrowPlacement = arrowPlacement_ }
                     )
                     { classesToHighlight = Set.empty
                     , placement = Tooltip.Top
                     , showStep = Nothing
                     , showStepLegend = True
+                    , arrowPlacement = Tooltip.Center
                     }
 
         absoluteCenter scale_ =
@@ -196,6 +200,7 @@ view { onChangeStep, translate, ariaLabel } optionalConfig attrs children_ =
                 Tooltip.Show
             )
         |> Tooltip.withPlacement placement
+        |> Tooltip.withArrowPlacement arrowPlacement
         |> Tooltip.withContent
             (\arrow ->
                 Html.column

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -1,12 +1,10 @@
 module Nordea.Components.Tooltip exposing
-    ( ArrowPlacement(..)
-    , Placement(..)
+    ( Placement(..)
     , Tooltip
     , Visibility(..)
     , infoTooltip
     , init
     , view
-    , withArrowPlacement
     , withContent
     , withPlacement
     , withVisibility
@@ -23,8 +21,11 @@ import Css
         , borderRadius
         , bottom
         , boxShadow4
+        , boxSizing
+        , calc
         , color
         , column
+        , contentBox
         , deg
         , display
         , displayFlex
@@ -41,10 +42,12 @@ import Css
         , marginTop
         , maxWidth
         , minWidth
+        , minus
         , ms
         , none
         , padding2
         , pct
+        , plus
         , position
         , pseudoClass
         , relative
@@ -72,15 +75,17 @@ import Nordea.Resources.Colors as Colors
 
 type Placement
     = Top
+    | TopRight
+    | TopLeft
     | Bottom
+    | BottomLeft
+    | BottomRight
     | Left
+    | LeftBottom
+    | LeftTop
     | Right
-
-
-type ArrowPlacement
-    = Center
-    | NearCorner
-    | NearOtherCorner
+    | RightBottom
+    | RightTop
 
 
 type Visibility
@@ -92,7 +97,6 @@ type Visibility
 
 type alias Config msg =
     { placement : Placement
-    , arrowDistanceFromCornerInPct : Float
     , content : (List (Attribute msg) -> Html msg) -> Html msg
     , visibility : Visibility
     }
@@ -106,7 +110,6 @@ init : Tooltip msg
 init =
     Tooltip
         { placement = Top
-        , arrowDistanceFromCornerInPct = 50
         , content = \_ -> Html.text ""
         , visibility = OnHoverFocus
         }
@@ -115,19 +118,6 @@ init =
 withPlacement : Placement -> Tooltip msg -> Tooltip msg
 withPlacement placement (Tooltip config) =
     Tooltip { config | placement = placement }
-
-
-withArrowPlacement : ArrowPlacement -> Tooltip msg -> Tooltip msg
-withArrowPlacement arrowPlacement (Tooltip config) =
-    case arrowPlacement of
-        NearCorner ->
-            Tooltip { config | arrowDistanceFromCornerInPct = 15 }
-
-        Center ->
-            Tooltip { config | arrowDistanceFromCornerInPct = 50 }
-
-        NearOtherCorner ->
-            Tooltip { config | arrowDistanceFromCornerInPct = 85 }
 
 
 withContent :
@@ -146,36 +136,113 @@ withVisibility visibility (Tooltip config) =
 view : List (Attribute msg) -> List (Html msg) -> Tooltip msg -> Html msg
 view attrs children (Tooltip config) =
     let
+        arrowDistanceFromCornerInPct =
+            15
+
+        arrowWidthInRem =
+            1
+
+        arrowHeightInRem =
+            1
+
+        arrowVerticalMarginInRem =
+            arrowHeightInRem * 0.65
+
+        arrowHorizontalMarginInRem =
+            arrowWidthInRem * 0.65
+
+        calcString lengthLeft unitLeft op lengthRight unitRight =
+            "calc(" ++ String.fromFloat lengthLeft ++ unitLeft ++ " " ++ op ++ " " ++ String.fromFloat lengthRight ++ unitRight ++ ")"
+
+        translateString x y =
+            "translate(" ++ x ++ ", " ++ y ++ ")"
+
         arrow arrowAttrs =
             let
                 arrowPosition =
                     case config.placement of
                         Top ->
                             Css.batch
-                                [ bottom (rem -0.66)
-                                , left (pct config.arrowDistanceFromCornerInPct)
-                                , transforms [ translateX (pct -config.arrowDistanceFromCornerInPct), rotate (deg 180) ]
+                                [ bottom (rem -arrowVerticalMarginInRem)
+                                , left (pct 50)
+                                , transforms [ translateX (pct -50), rotate (deg 180) ]
+                                ]
+
+                        TopRight ->
+                            Css.batch
+                                [ bottom (rem -arrowVerticalMarginInRem)
+                                , left (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowWidthInRem))
+                                , transforms [ translateX (pct -50), rotate (deg 180) ]
+                                ]
+
+                        TopLeft ->
+                            Css.batch
+                                [ bottom (rem -arrowVerticalMarginInRem)
+                                , left (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowWidthInRem))
+                                , transforms [ translateX (pct -50), rotate (deg 180) ]
                                 ]
 
                         Bottom ->
                             Css.batch
-                                [ top (rem -0.66)
-                                , left (pct config.arrowDistanceFromCornerInPct)
-                                , transforms [ translateX (pct -config.arrowDistanceFromCornerInPct) ]
+                                [ top (rem -arrowHorizontalMarginInRem)
+                                , left (pct 50)
+                                , transforms [ translateX (pct -50) ]
+                                ]
+
+                        BottomLeft ->
+                            Css.batch
+                                [ top (rem -arrowVerticalMarginInRem)
+                                , left (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowWidthInRem))
+                                , transforms [ translateX (pct -50) ]
+                                ]
+
+                        BottomRight ->
+                            Css.batch
+                                [ top (rem -arrowVerticalMarginInRem)
+                                , left (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowWidthInRem))
+                                , transforms [ translateX (pct -50) ]
                                 ]
 
                         Left ->
                             Css.batch
-                                [ right (rem -0.66)
-                                , top (pct config.arrowDistanceFromCornerInPct)
-                                , transforms [ translateY (pct -config.arrowDistanceFromCornerInPct), rotate (deg 90) ]
+                                [ right (rem -arrowHorizontalMarginInRem)
+                                , top (pct 50)
+                                , transforms [ translateY (pct -50), rotate (deg 90) ]
+                                ]
+
+                        LeftBottom ->
+                            Css.batch
+                                [ right (rem -arrowHorizontalMarginInRem)
+                                , top (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowHeightInRem))
+                                , transforms [ translateY (pct -50), rotate (deg 90) ]
+                                ]
+
+                        LeftTop ->
+                            Css.batch
+                                [ right (rem -arrowHorizontalMarginInRem)
+                                , top (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowHeightInRem))
+                                , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
                         Right ->
                             Css.batch
-                                [ left (rem -0.66)
-                                , top (pct config.arrowDistanceFromCornerInPct)
-                                , transforms [ translateY (pct -config.arrowDistanceFromCornerInPct), rotate (deg -90) ]
+                                [ left (rem -arrowHorizontalMarginInRem)
+                                , top (pct 50)
+                                , transforms [ translateY (pct -50), rotate (deg -90) ]
+                                ]
+
+                        RightTop ->
+                            Css.batch
+                                [ left (rem -arrowHorizontalMarginInRem)
+                                , top (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowHeightInRem))
+                                , transforms [ translateY (pct -50), rotate (deg -90) ]
+                                ]
+
+                        RightBottom ->
+                            Css.batch
+                                [ left (rem -arrowHorizontalMarginInRem)
+                                , top (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowHeightInRem))
+                                , transforms [ translateY (pct -50), rotate (deg -90) ]
                                 ]
             in
             Html.div
@@ -184,8 +251,8 @@ view attrs children (Tooltip config) =
                     , position absolute
                     , Css.property "clip-path" "polygon(50% 20%, 100% 70%, 0 70%)"
                     , arrowPosition
-                    , width (rem 1)
-                    , height (rem 1)
+                    , width (rem arrowWidthInRem)
+                    , height (rem arrowHeightInRem)
                     , backgroundColor inherit
                     ]
                     :: arrowAttrs
@@ -199,29 +266,93 @@ view attrs children (Tooltip config) =
                         Top ->
                             Css.batch
                                 [ top (rem 0)
-                                , left (pct config.arrowDistanceFromCornerInPct)
-                                , transform (translate2 (pct -config.arrowDistanceFromCornerInPct) (pct -100))
+                                , left (pct 50)
+                                , transform (translate2 (pct -50) (pct -100))
+                                ]
+
+                        TopRight ->
+                            Css.batch
+                                [ top (rem 0)
+                                , left (pct 50)
+                                , Css.property "transform"
+                                    (translateString (calcString -arrowDistanceFromCornerInPct "%" "-" arrowWidthInRem "rem") "-100%")
+                                ]
+
+                        TopLeft ->
+                            Css.batch
+                                [ top (rem 0)
+                                , left (pct 50)
+                                , Css.property "transform"
+                                    (translateString (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowWidthInRem "rem") "-100%")
                                 ]
 
                         Bottom ->
                             Css.batch
                                 [ bottom (rem 0)
-                                , left (pct config.arrowDistanceFromCornerInPct)
-                                , transform (translate2 (pct -config.arrowDistanceFromCornerInPct) (pct 100))
+                                , left (pct 50)
+                                , transform (translate2 (pct -50) (pct 100))
+                                ]
+
+                        BottomLeft ->
+                            Css.batch
+                                [ bottom (rem 0)
+                                , left (pct 50)
+                                , Css.property "transform"
+                                    (translateString (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowWidthInRem "rem") "100%")
+                                ]
+
+                        BottomRight ->
+                            Css.batch
+                                [ bottom (rem 0)
+                                , left (pct 50)
+                                , Css.property "transform"
+                                    (translateString (calcString -arrowDistanceFromCornerInPct "%" "-" arrowWidthInRem "rem") "100%")
                                 ]
 
                         Left ->
                             Css.batch
                                 [ left (rem 0)
-                                , top (pct config.arrowDistanceFromCornerInPct)
-                                , transform (translate2 (pct -100) (pct -config.arrowDistanceFromCornerInPct))
+                                , top (pct 50)
+                                , transform (translate2 (pct -100) (pct -50))
+                                ]
+
+                        LeftBottom ->
+                            Css.batch
+                                [ left (rem 0)
+                                , top (pct 50)
+                                , Css.property "transform"
+                                    (translateString "-100%" (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowHeightInRem "rem"))
+                                ]
+
+                        LeftTop ->
+                            Css.batch
+                                [ left (rem 0)
+                                , top (pct 50)
+                                , Css.property "transform"
+                                    (translateString "-100%" (calcString -arrowDistanceFromCornerInPct "%" "-" arrowHeightInRem "rem"))
                                 ]
 
                         Right ->
                             Css.batch
                                 [ right (rem 0)
-                                , top (pct config.arrowDistanceFromCornerInPct)
-                                , transform (translate2 (pct 100) (pct -config.arrowDistanceFromCornerInPct))
+                                , top (pct 50)
+                                , transform (translate2 (pct 100) (pct -50))
+                                ]
+
+                        RightTop ->
+                            Css.batch
+                                [ right (rem 0)
+                                , top (pct 50)
+                                , Css.property "transform"
+                                    (translateString "100%" (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowHeightInRem "rem"))
+                                ]
+
+                        RightBottom ->
+                            Css.batch
+                                [ right (rem 0)
+                                , top (pct 50)
+                                , Css.property "transform"
+                                    (translateString "100%" (calcString -arrowDistanceFromCornerInPct "%" "-" arrowHeightInRem "rem"))
                                 ]
             in
             Html.div
@@ -232,6 +363,8 @@ view attrs children (Tooltip config) =
                     , flexDirection column
                     , zIndex (int 100)
                     , minWidth (pct 100)
+
+                    --, Css.property "translate" "35%"
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->
@@ -283,17 +416,42 @@ view attrs children (Tooltip config) =
                 |> styleIf (config.visibility == OnHoverFocus)
             , descendants
                 [ class "tooltip-content-default-margin"
-                    [ case config.placement of
+                    [ --left (pct 35)
+                      case config.placement of
                         Top ->
+                            marginBottom (rem 1)
+
+                        TopRight ->
+                            marginBottom (rem 1)
+
+                        TopLeft ->
                             marginBottom (rem 1)
 
                         Bottom ->
                             marginTop (rem 1)
 
+                        BottomLeft ->
+                            marginTop (rem 1)
+
+                        BottomRight ->
+                            marginTop (rem 1)
+
                         Left ->
                             marginRight (rem 1)
 
+                        LeftBottom ->
+                            marginRight (rem 1)
+
+                        LeftTop ->
+                            marginRight (rem 1)
+
                         Right ->
+                            marginLeft (rem 1)
+
+                        RightBottom ->
+                            marginLeft (rem 1)
+
+                        RightTop ->
                             marginLeft (rem 1)
                     ]
                 ]
@@ -315,6 +473,7 @@ infoTooltip attrs children arrow =
             , boxShadow4 zero (rem 0.0625) (rem 0.125) (rgba 0 0 0 0.2)
             , Css.property "width" "max-content"
             , maxWidth (rem 20)
+            , boxSizing contentBox
             , position relative
             ]
          ]

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -41,7 +41,6 @@ import Css
         , marginRight
         , marginTop
         , maxWidth
-        , minWidth
         , minus
         , ms
         , none
@@ -136,8 +135,8 @@ withVisibility visibility (Tooltip config) =
 view : List (Attribute msg) -> List (Html msg) -> Tooltip msg -> Html msg
 view attrs children (Tooltip config) =
     let
-        arrowDistanceFromCornerInPct =
-            15
+        arrowDistanceFromCornerInRem =
+            0.25
 
         arrowWidthInRem =
             1
@@ -171,14 +170,14 @@ view attrs children (Tooltip config) =
                         TopRight ->
                             Css.batch
                                 [ bottom (rem -arrowVerticalMarginInRem)
-                                , left (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowWidthInRem))
+                                , left (calc (rem arrowDistanceFromCornerInRem) plus (rem arrowWidthInRem))
                                 , transforms [ translateX (pct -50), rotate (deg 180) ]
                                 ]
 
                         TopLeft ->
                             Css.batch
                                 [ bottom (rem -arrowVerticalMarginInRem)
-                                , left (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowWidthInRem))
+                                , left (calc (pct 100) minus (rem (arrowWidthInRem + arrowDistanceFromCornerInRem)))
                                 , transforms [ translateX (pct -50), rotate (deg 180) ]
                                 ]
 
@@ -192,14 +191,14 @@ view attrs children (Tooltip config) =
                         BottomLeft ->
                             Css.batch
                                 [ top (rem -arrowVerticalMarginInRem)
-                                , left (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowWidthInRem))
+                                , left (calc (pct 100) minus (rem (arrowWidthInRem + arrowDistanceFromCornerInRem)))
                                 , transforms [ translateX (pct -50) ]
                                 ]
 
                         BottomRight ->
                             Css.batch
                                 [ top (rem -arrowVerticalMarginInRem)
-                                , left (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowWidthInRem))
+                                , left (calc (rem arrowDistanceFromCornerInRem) plus (rem arrowWidthInRem))
                                 , transforms [ translateX (pct -50) ]
                                 ]
 
@@ -213,14 +212,14 @@ view attrs children (Tooltip config) =
                         LeftBottom ->
                             Css.batch
                                 [ right (rem -arrowHorizontalMarginInRem)
-                                , top (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowHeightInRem))
+                                , top (calc (pct 100) minus (rem (arrowHeightInRem + arrowDistanceFromCornerInRem)))
                                 , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
                         LeftTop ->
                             Css.batch
                                 [ right (rem -arrowHorizontalMarginInRem)
-                                , top (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowHeightInRem))
+                                , top (calc (rem arrowDistanceFromCornerInRem) plus (rem arrowHeightInRem))
                                 , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
@@ -234,14 +233,14 @@ view attrs children (Tooltip config) =
                         RightTop ->
                             Css.batch
                                 [ left (rem -arrowHorizontalMarginInRem)
-                                , top (calc (pct (100 - arrowDistanceFromCornerInPct)) minus (rem arrowHeightInRem))
+                                , top (calc (pct 100) minus (rem (arrowHeightInRem + arrowDistanceFromCornerInRem)))
                                 , transforms [ translateY (pct -50), rotate (deg -90) ]
                                 ]
 
                         RightBottom ->
                             Css.batch
                                 [ left (rem -arrowHorizontalMarginInRem)
-                                , top (calc (pct arrowDistanceFromCornerInPct) plus (rem arrowHeightInRem))
+                                , top (calc (rem arrowDistanceFromCornerInRem) plus (rem arrowHeightInRem))
                                 , transforms [ translateY (pct -50), rotate (deg -90) ]
                                 ]
             in
@@ -275,7 +274,7 @@ view attrs children (Tooltip config) =
                                 [ top (rem 0)
                                 , left (pct 50)
                                 , Css.property "transform"
-                                    (translateString (calcString -arrowDistanceFromCornerInPct "%" "-" arrowWidthInRem "rem") "-100%")
+                                    (translateString (calcString -arrowDistanceFromCornerInRem "rem" "-" arrowWidthInRem "rem") "-100%")
                                 ]
 
                         TopLeft ->
@@ -283,7 +282,7 @@ view attrs children (Tooltip config) =
                                 [ top (rem 0)
                                 , left (pct 50)
                                 , Css.property "transform"
-                                    (translateString (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowWidthInRem "rem") "-100%")
+                                    (translateString (calcString -100 "%" "+" (arrowWidthInRem + arrowDistanceFromCornerInRem) "rem") "-100%")
                                 ]
 
                         Bottom ->
@@ -298,7 +297,7 @@ view attrs children (Tooltip config) =
                                 [ bottom (rem 0)
                                 , left (pct 50)
                                 , Css.property "transform"
-                                    (translateString (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowWidthInRem "rem") "100%")
+                                    (translateString (calcString -100 "%" "+" (arrowWidthInRem + arrowDistanceFromCornerInRem) "rem") "100%")
                                 ]
 
                         BottomRight ->
@@ -306,7 +305,7 @@ view attrs children (Tooltip config) =
                                 [ bottom (rem 0)
                                 , left (pct 50)
                                 , Css.property "transform"
-                                    (translateString (calcString -arrowDistanceFromCornerInPct "%" "-" arrowWidthInRem "rem") "100%")
+                                    (translateString (calcString -arrowDistanceFromCornerInRem "rem" "-" arrowWidthInRem "rem") "100%")
                                 ]
 
                         Left ->
@@ -321,7 +320,7 @@ view attrs children (Tooltip config) =
                                 [ left (rem 0)
                                 , top (pct 50)
                                 , Css.property "transform"
-                                    (translateString "-100%" (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowHeightInRem "rem"))
+                                    (translateString "-100%" (calcString -100 "%" "+" (arrowHeightInRem + arrowDistanceFromCornerInRem) "rem"))
                                 ]
 
                         LeftTop ->
@@ -329,7 +328,7 @@ view attrs children (Tooltip config) =
                                 [ left (rem 0)
                                 , top (pct 50)
                                 , Css.property "transform"
-                                    (translateString "-100%" (calcString -arrowDistanceFromCornerInPct "%" "-" arrowHeightInRem "rem"))
+                                    (translateString "-100%" (calcString -arrowDistanceFromCornerInRem "rem" "-" arrowHeightInRem "rem"))
                                 ]
 
                         Right ->
@@ -344,7 +343,7 @@ view attrs children (Tooltip config) =
                                 [ right (rem 0)
                                 , top (pct 50)
                                 , Css.property "transform"
-                                    (translateString "100%" (calcString -(100 - arrowDistanceFromCornerInPct) "%" "+" arrowHeightInRem "rem"))
+                                    (translateString "100%" (calcString -100 "%" "+" (arrowHeightInRem + arrowDistanceFromCornerInRem) "rem"))
                                 ]
 
                         RightBottom ->
@@ -352,7 +351,7 @@ view attrs children (Tooltip config) =
                                 [ right (rem 0)
                                 , top (pct 50)
                                 , Css.property "transform"
-                                    (translateString "100%" (calcString -arrowDistanceFromCornerInPct "%" "-" arrowHeightInRem "rem"))
+                                    (translateString "100%" (calcString -arrowDistanceFromCornerInRem "rem" "-" arrowHeightInRem "rem"))
                                 ]
             in
             Html.div
@@ -362,7 +361,6 @@ view attrs children (Tooltip config) =
                     , display none
                     , flexDirection column
                     , zIndex (int 100)
-                    , minWidth (pct 100)
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -363,8 +363,6 @@ view attrs children (Tooltip config) =
                     , flexDirection column
                     , zIndex (int 100)
                     , minWidth (pct 100)
-
-                    --, Css.property "translate" "35%"
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->
@@ -416,8 +414,7 @@ view attrs children (Tooltip config) =
                 |> styleIf (config.visibility == OnHoverFocus)
             , descendants
                 [ class "tooltip-content-default-margin"
-                    [ --left (pct 35)
-                      case config.placement of
+                    [ case config.placement of
                         Top ->
                             marginBottom (rem 1)
 

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -1,10 +1,12 @@
 module Nordea.Components.Tooltip exposing
-    ( Placement(..)
+    ( ArrowPlacement(..)
+    , Placement(..)
     , Tooltip
     , Visibility(..)
     , infoTooltip
     , init
     , view
+    , withArrowPlacement
     , withContent
     , withPlacement
     , withVisibility
@@ -75,6 +77,12 @@ type Placement
     | Right
 
 
+type ArrowPlacement
+    = Center
+    | NearCorner
+    | NearOtherCorner
+
+
 type Visibility
     = OnHoverFocus
     | FadeOutMs Float
@@ -84,6 +92,7 @@ type Visibility
 
 type alias Config msg =
     { placement : Placement
+    , arrowDistanceFromCornerInPct : Float
     , content : (List (Attribute msg) -> Html msg) -> Html msg
     , visibility : Visibility
     }
@@ -97,6 +106,7 @@ init : Tooltip msg
 init =
     Tooltip
         { placement = Top
+        , arrowDistanceFromCornerInPct = 50
         , content = \_ -> Html.text ""
         , visibility = OnHoverFocus
         }
@@ -105,6 +115,19 @@ init =
 withPlacement : Placement -> Tooltip msg -> Tooltip msg
 withPlacement placement (Tooltip config) =
     Tooltip { config | placement = placement }
+
+
+withArrowPlacement : ArrowPlacement -> Tooltip msg -> Tooltip msg
+withArrowPlacement arrowPlacement (Tooltip config) =
+    case arrowPlacement of
+        NearCorner ->
+            Tooltip { config | arrowDistanceFromCornerInPct = 15 }
+
+        Center ->
+            Tooltip { config | arrowDistanceFromCornerInPct = 50 }
+
+        NearOtherCorner ->
+            Tooltip { config | arrowDistanceFromCornerInPct = 85 }
 
 
 withContent :
@@ -130,29 +153,29 @@ view attrs children (Tooltip config) =
                         Top ->
                             Css.batch
                                 [ bottom (rem -0.66)
-                                , left (pct 50)
-                                , transforms [ translateX (pct -50), rotate (deg 180) ]
+                                , left (pct config.arrowDistanceFromCornerInPct)
+                                , transforms [ translateX (pct -config.arrowDistanceFromCornerInPct), rotate (deg 180) ]
                                 ]
 
                         Bottom ->
                             Css.batch
                                 [ top (rem -0.66)
-                                , left (pct 50)
-                                , transforms [ translateX (pct -50) ]
+                                , left (pct config.arrowDistanceFromCornerInPct)
+                                , transforms [ translateX (pct -config.arrowDistanceFromCornerInPct) ]
                                 ]
 
                         Left ->
                             Css.batch
                                 [ right (rem -0.66)
-                                , top (pct 50)
-                                , transforms [ translateY (pct -50), rotate (deg 90) ]
+                                , top (pct config.arrowDistanceFromCornerInPct)
+                                , transforms [ translateY (pct -config.arrowDistanceFromCornerInPct), rotate (deg 90) ]
                                 ]
 
                         Right ->
                             Css.batch
                                 [ left (rem -0.66)
-                                , top (pct 50)
-                                , transforms [ translateY (pct -50), rotate (deg -90) ]
+                                , top (pct config.arrowDistanceFromCornerInPct)
+                                , transforms [ translateY (pct -config.arrowDistanceFromCornerInPct), rotate (deg -90) ]
                                 ]
             in
             Html.div
@@ -176,29 +199,29 @@ view attrs children (Tooltip config) =
                         Top ->
                             Css.batch
                                 [ top (rem 0)
-                                , left (pct 50)
-                                , transform (translate2 (pct -50) (pct -100))
+                                , left (pct config.arrowDistanceFromCornerInPct)
+                                , transform (translate2 (pct -config.arrowDistanceFromCornerInPct) (pct -100))
                                 ]
 
                         Bottom ->
                             Css.batch
                                 [ bottom (rem 0)
-                                , left (pct 50)
-                                , transform (translate2 (pct -50) (pct 100))
+                                , left (pct config.arrowDistanceFromCornerInPct)
+                                , transform (translate2 (pct -config.arrowDistanceFromCornerInPct) (pct 100))
                                 ]
 
                         Left ->
                             Css.batch
                                 [ left (rem 0)
-                                , top (pct 50)
-                                , transform (translate2 (pct -100) (pct -50))
+                                , top (pct config.arrowDistanceFromCornerInPct)
+                                , transform (translate2 (pct -100) (pct -config.arrowDistanceFromCornerInPct))
                                 ]
 
                         Right ->
                             Css.batch
                                 [ right (rem 0)
-                                , top (pct 50)
-                                , transform (translate2 (pct 100) (pct -50))
+                                , top (pct config.arrowDistanceFromCornerInPct)
+                                , transform (translate2 (pct 100) (pct -config.arrowDistanceFromCornerInPct))
                                 ]
             in
             Html.div

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -80,8 +80,8 @@ type Placement
     | BottomLeft
     | BottomRight
     | Left
-    | LeftBottom
     | LeftTop
+    | LeftBottom
     | Right
     | RightBottom
     | RightTop
@@ -209,14 +209,14 @@ view attrs children (Tooltip config) =
                                 , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
-                        LeftBottom ->
+                        LeftTop ->
                             Css.batch
                                 [ right (rem -arrowHorizontalMarginInRem)
                                 , top (calc (pct 100) minus (rem (arrowHeightInRem + arrowDistanceFromCornerInRem)))
                                 , transforms [ translateY (pct -50), rotate (deg 90) ]
                                 ]
 
-                        LeftTop ->
+                        LeftBottom ->
                             Css.batch
                                 [ right (rem -arrowHorizontalMarginInRem)
                                 , top (calc (rem arrowDistanceFromCornerInRem) plus (rem arrowHeightInRem))
@@ -315,7 +315,7 @@ view attrs children (Tooltip config) =
                                 , transform (translate2 (pct -100) (pct -50))
                                 ]
 
-                        LeftBottom ->
+                        LeftTop ->
                             Css.batch
                                 [ left (rem 0)
                                 , top (pct 50)
@@ -323,7 +323,7 @@ view attrs children (Tooltip config) =
                                     (translateString "-100%" (calcString -100 "%" "+" (arrowHeightInRem + arrowDistanceFromCornerInRem) "rem"))
                                 ]
 
-                        LeftTop ->
+                        LeftBottom ->
                             Css.batch
                                 [ left (rem 0)
                                 , top (pct 50)
@@ -434,10 +434,10 @@ view attrs children (Tooltip config) =
                         Left ->
                             marginRight (rem 1)
 
-                        LeftBottom ->
+                        LeftTop ->
                             marginRight (rem 1)
 
-                        LeftTop ->
+                        LeftBottom ->
                             marginRight (rem 1)
 
                         Right ->


### PR DESCRIPTION
The design library has more placements than just the arrow being on the center.

https://www.figma.com/file/tgFkTfmNZE0zwx44OeaohE/New-Design-System-anno-2023?type=design&node-id=8-1997&mode=design&t=2juhpiu62fIbnojD-0

![image](https://github.com/SGFinansAS/elm-components/assets/34012758/1faf72c3-f770-4cf4-adc7-43627e2d13df)


Introduce 3 variants, `NearCorner, NearOtherCorner, Center` for arrow placement.
![image](https://github.com/SGFinansAS/elm-components/assets/34012758/5c08e1f7-e652-4dc0-9845-68af113104fd)


