### PR TITLE
PAR-2747: Adjustments to small text input to use with icons

### DIFF
--- a/explorer/src/Stories/TextInput.elm
+++ b/explorer/src/Stories/TextInput.elm
@@ -82,9 +82,17 @@ stories =
                     |> TextInput.view []
           , {}
           )
-        , ( "With small size"
+        , ( "Small"
           , \_ ->
                 TextInput.init "Text"
+                    |> TextInput.withSmallSize
+                    |> TextInput.view []
+          , {}
+          )
+        , ( "Small with search icon"
+          , \_ ->
+                TextInput.init "Text"
+                    |> TextInput.withSearchIcon True
                     |> TextInput.withSmallSize
                     |> TextInput.view []
           , {}

--- a/src/Nordea/Components/TextInput.elm
+++ b/src/Nordea/Components/TextInput.elm
@@ -221,17 +221,25 @@ view attributes (TextInput config) =
                 |> showIf config.hasSearchIcon
 
         viewClearIcon =
+            let
+                sizeSpecificStyling =
+                    if config.size == Small then
+                        [ width (rem 1.5), padding4 (rem 0.2) (rem 0.125) (rem 0.125) (rem 0.125) ]
+
+                    else
+                        [ width (rem 2.5), padding4 (rem 0.35) (rem 0.25) (rem 0.25) (rem 0.25) ]
+            in
             Icons.roundedCross
                 (Maybe.values
                     [ Just
                         (css
-                            [ width (rem 2.5)
-                            , color Colors.mediumGray
-                            , position absolute
-                            , padding4 (rem 0.35) (rem 0.25) (rem 0.25) (rem 0.25)
-                            , right (rem 0)
-                            , cursor pointer
-                            ]
+                            (sizeSpecificStyling
+                                ++ [ color Colors.mediumGray
+                                   , position absolute
+                                   , right (rem 0)
+                                   , cursor pointer
+                                   ]
+                            )
                         )
                     , config.onInput |> Maybe.map (\onInput -> onClick (onInput ""))
                     , Just (tabindex 0)
@@ -253,15 +261,28 @@ view attributes (TextInput config) =
 
 viewCurrency : Config msg -> Html msg
 viewCurrency config =
+    let
+        initText =
+            case config.size of
+                Standard ->
+                    Text.textHeavy
+
+                Small ->
+                    Text.textTinyHeavy
+    in
     config.currency
         |> Html.viewMaybe
             (\currency ->
-                Text.textHeavy
+                initText
                     |> Text.view
                         [ css
                             [ position absolute
                             , right (rem 0.7)
-                            , top (pct 30)
+                            , if config.size == Small then
+                                top (pct 20)
+
+                              else
+                                top (pct 30)
                             ]
                         ]
                         [ currency
@@ -305,28 +326,33 @@ getStyles config =
                     [ fontSize (rem 0.75)
                     , height (rem 1.5)
                     , padding2 (rem 0.25) (rem 0.5)
+                    , paddingRight (rem 1.5)
+                        |> styleIf
+                            ((config.value |> String.isEmpty |> not)
+                                && config.hasClearIcon
+                            )
                     ]
 
                 Standard ->
                     [ fontSize (rem 1)
                     , height (rem 2.5)
                     , padding2 (rem 0) (rem 0.75)
+                    , paddingRight (rem 3)
+                        |> styleIf
+                            ((config.value |> String.isEmpty |> not)
+                                && config.hasClearIcon
+                            )
                     ]
     in
-    [ borderRadius (rem 0.25)
-    , border3 (rem 0.0625) solid borderColorStyle
-    , boxSizing borderBox
-    , width (pct 100)
-    , disabled [ backgroundColor Colors.grayWarm ]
-    , paddingLeft (rem 2) |> styleIf config.hasSearchIcon
-    , paddingRight (rem 3)
-        |> styleIf
-            ((config.value |> String.isEmpty |> not)
-                && config.hasClearIcon
-            )
-    , focus
-        [ outline none
-        , Themes.borderColor Colors.nordeaBlue
-        ]
-    ]
-        ++ sizeSpecificStyling
+    sizeSpecificStyling
+        ++ [ borderRadius (rem 0.25)
+           , border3 (rem 0.0625) solid borderColorStyle
+           , boxSizing borderBox
+           , width (pct 100)
+           , disabled [ backgroundColor Colors.grayWarm ]
+           , paddingLeft (rem 2) |> styleIf config.hasSearchIcon
+           , focus
+                [ outline none
+                , Themes.borderColor Colors.nordeaBlue
+                ]
+           ]


### PR DESCRIPTION
Fix padding on Standard input field 
![image](https://github.com/SGFinansAS/elm-components/assets/10939030/072104e0-48b6-4834-b254-81082da3fcdf)
![image](https://github.com/SGFinansAS/elm-components/assets/10939030/3ab46bad-53eb-4279-9a1f-c677ce03e358)
Small with search icon
![image](https://github.com/SGFinansAS/elm-components/assets/10939030/83d79911-e68d-4d11-9a70-caec2fafd385)
Small with currency
![image](https://github.com/SGFinansAS/elm-components/assets/10939030/90ed8d1b-4835-45eb-b6f7-bb9dd811aa3a)
Small with cancel icon
![image](https://github.com/SGFinansAS/elm-components/assets/10939030/08e618d7-b313-490d-aa12-b793c58ccc95)
