### PR TITLE
fix tooltip width and z-index issue

### DIFF
--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -9,8 +9,52 @@ module Nordea.Components.DropdownFilter exposing
     , withSearchIcon
     )
 
-import Css exposing (absolute, alignItems, backgroundColor, borderBottom3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderLeft3, borderRight3, boxSizing, center, color, column, cursor, deg, displayFlex, flexDirection, height, hover, justifyContent, listStyle, margin2, marginTop, maxHeight, minWidth, none, overflowY, padding, padding3, paddingRight, pct, pointer, pointerEvents, position, rem, right, rotate, scroll, solid, top, transforms, translateY, width)
-import Css.Global exposing (children, class, descendants, typeSelector)
+import Css
+    exposing
+        ( absolute
+        , alignItems
+        , backgroundColor
+        , borderBottom3
+        , borderBottomLeftRadius
+        , borderBottomRightRadius
+        , borderBox
+        , borderLeft3
+        , borderRight3
+        , boxSizing
+        , center
+        , color
+        , column
+        , cursor
+        , deg
+        , displayFlex
+        , flexDirection
+        , height
+        , hover
+        , justifyContent
+        , listStyle
+        , margin2
+        , marginTop
+        , maxHeight
+        , none
+        , overflowY
+        , padding
+        , padding3
+        , paddingRight
+        , pct
+        , pointer
+        , pointerEvents
+        , position
+        , rem
+        , right
+        , rotate
+        , scroll
+        , solid
+        , top
+        , transforms
+        , translateY
+        , width
+        )
+import Css.Global exposing (class, descendants, typeSelector)
 import Html.Events.Extra as Events
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attrs exposing (css, tabindex, value)

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -9,52 +9,8 @@ module Nordea.Components.DropdownFilter exposing
     , withSearchIcon
     )
 
-import Css
-    exposing
-        ( absolute
-        , alignItems
-        , backgroundColor
-        , borderBottom3
-        , borderBottomLeftRadius
-        , borderBottomRightRadius
-        , borderBox
-        , borderLeft3
-        , borderRight3
-        , boxSizing
-        , center
-        , color
-        , column
-        , cursor
-        , deg
-        , displayFlex
-        , flexDirection
-        , height
-        , hover
-        , justifyContent
-        , listStyle
-        , margin2
-        , marginTop
-        , maxHeight
-        , none
-        , overflowY
-        , padding
-        , padding3
-        , paddingRight
-        , pct
-        , pointer
-        , pointerEvents
-        , position
-        , rem
-        , right
-        , rotate
-        , scroll
-        , solid
-        , top
-        , transforms
-        , translateY
-        , width
-        )
-import Css.Global exposing (descendants, typeSelector)
+import Css exposing (absolute, alignItems, backgroundColor, borderBottom3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderLeft3, borderRight3, boxSizing, center, color, column, cursor, deg, displayFlex, flexDirection, height, hover, justifyContent, listStyle, margin2, marginTop, maxHeight, minWidth, none, overflowY, padding, padding3, paddingRight, pct, pointer, pointerEvents, position, rem, right, rotate, scroll, solid, top, transforms, translateY, width)
+import Css.Global exposing (children, class, descendants, typeSelector)
 import Html.Events.Extra as Events
 import Html.Styled as Html exposing (Html)
 import Html.Styled.Attributes as Attrs exposing (css, tabindex, value)
@@ -233,7 +189,7 @@ view attrs (DropdownFilter config) =
                 Tooltip.Show
 
              else
-                Tooltip.Hidden
+                Tooltip.Show
             )
         |> Tooltip.withContent
             (\_ ->
@@ -268,6 +224,7 @@ view attrs (DropdownFilter config) =
                     (\onFocus ->
                         [ Events.on "focusout" (Decode.succeed (onFocus False))
                         , Events.on "focusin" (Decode.succeed (onFocus True))
+                        , css [ descendants [ class "tooltip" [ width (pct 100) ] ] ]
                         ]
                     )
                 |> Maybe.withDefault []

--- a/src/Nordea/Components/DropdownFilter.elm
+++ b/src/Nordea/Components/DropdownFilter.elm
@@ -233,7 +233,7 @@ view attrs (DropdownFilter config) =
                 Tooltip.Show
 
              else
-                Tooltip.Show
+                Tooltip.Hidden
             )
         |> Tooltip.withContent
             (\_ ->

--- a/src/Nordea/Components/Tooltip.elm
+++ b/src/Nordea/Components/Tooltip.elm
@@ -41,7 +41,6 @@ import Css
         , marginRight
         , marginTop
         , maxWidth
-        , minWidth
         , minus
         , ms
         , none
@@ -362,7 +361,6 @@ view attrs children (Tooltip config) =
                     , display none
                     , flexDirection column
                     , zIndex (int 100)
-                    , minWidth (pct 100)
                     , tooltipPosition
                     , case config.visibility of
                         FadeOutMs duration ->


### PR DESCRIPTION
`min-width` was removed some time ago from tooltip and later it caused issues for `DropdownFilter`, and as part of fix it was added again here https://github.com/SGFinansAS/elm-components/pull/345

But the fix there also caused an issue in tooltip like below

![image](https://github.com/SGFinansAS/elm-components/assets/34012758/ea33b1ed-fa9c-4c10-8b69-b1067cbfb846)

The tooltip lost its position at the center, and `min-width` caused the tooltip to cover a very large area (as big as the element that is being tooltipped). This is bad because you cannot click anything because of z-index.

Now with this fix, both dropdown and tooltip should work as intended.

![image](https://github.com/SGFinansAS/elm-components/assets/34012758/6070a5c8-0e13-488f-8918-7dbcfac70224)
![image](https://github.com/SGFinansAS/elm-components/assets/34012758/877d86ab-f476-4470-914d-c89d23a4ad4a)
