### PR TITLE
Add gap css function

### DIFF
--- a/explorer/src/Stories/Card.elm
+++ b/explorer/src/Stories/Card.elm
@@ -4,6 +4,7 @@ import Css exposing (alignItems, center, rem, width)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card
+import Nordea.Css exposing (gap)
 import Nordea.Html as Html
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
@@ -65,12 +66,12 @@ stories =
                     |> Card.withTitle "Card title"
                     |> Card.withShadow
                     |> Card.view []
-                        [ Card.infoBox [ css [ Css.property "gap" "1rem" ] ]
-                            [ Html.row [ css [ alignItems center, Css.property "gap" "0.5rem" ] ]
+                        [ Card.infoBox [ css [ gap (rem 1) ] ]
+                            [ Html.row [ css [ alignItems center, gap (rem 0.5) ] ]
                                 [ Icons.filledCheckmark [ css [ width (rem 1.5) ] ]
                                 , Html.text "Some completed task"
                                 ]
-                            , Html.row [ css [ alignItems center, Css.property "gap" "0.5rem" ] ]
+                            , Html.row [ css [ alignItems center, gap (rem 0.5) ] ]
                                 [ Icons.unfilledMark [ css [ width (rem 1.5) ] ]
                                 , Html.text "Some not completed task"
                                 ]

--- a/explorer/src/Stories/Checkbox.elm
+++ b/explorer/src/Stories/Checkbox.elm
@@ -6,6 +6,7 @@ import Html.Styled as Html exposing (text)
 import Html.Styled.Attributes exposing (css, disabled)
 import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -16,7 +17,7 @@ stories =
         "Checkbox"
         [ ( "Standard"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "simple"
                         (text "Click me")
@@ -33,7 +34,7 @@ stories =
           )
         , ( "Standard with error"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "simple"
                         (text "Click me")
@@ -52,7 +53,7 @@ stories =
           )
         , ( "Standard disabled"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "standard"
                         (text "Click me")
@@ -69,7 +70,7 @@ stories =
           )
         , ( "Small"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "small"
                         (Text.textTinyLight |> Text.view [] [ text "Click me" ])
@@ -88,7 +89,7 @@ stories =
           )
         , ( "Small with error"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "small"
                         (Text.textTinyLight |> Text.view [] [ text "Click me" ])
@@ -109,7 +110,7 @@ stories =
           )
         , ( "Simple"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "simple"
                         (text "Click me")
@@ -128,7 +129,7 @@ stories =
           )
         , ( "Simple with error"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "simple"
                         (text "Click me")
@@ -149,7 +150,7 @@ stories =
           )
         , ( "Simple disabled"
           , \_ ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Checkbox.init
                         "simple"
                         (text "Click me")

--- a/explorer/src/Stories/Coachmark.elm
+++ b/explorer/src/Stories/Coachmark.elm
@@ -1,12 +1,13 @@
 module Stories.Coachmark exposing (stories)
 
 import Config exposing (Config, Msg(..))
-import Css exposing (displayFlex)
+import Css exposing (displayFlex, rem)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (class, css)
 import Nordea.Components.Button as Button
 import Nordea.Components.Coachmark as Coachmark
 import Nordea.Components.Tooltip as Tooltip
+import Nordea.Css exposing (gap)
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -17,7 +18,7 @@ stories =
         "Coachmark"
         [ ( "Standard"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ Button.secondary
                         |> Button.view [ class "new-button" ] [ Html.text "Some new feature button" ]
                     , Coachmark.view

--- a/explorer/src/Stories/Colors.elm
+++ b/explorer/src/Stories/Colors.elm
@@ -21,6 +21,7 @@ import Css
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Resources.Colors as Colors
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -56,7 +57,7 @@ stories =
                 ]
 
         colorsRow colors =
-            Html.div [ css [ displayFlex, flexDirection row, Css.property "gap" "2rem", marginBottom (rem 1.125) ] ]
+            Html.div [ css [ displayFlex, flexDirection row, gap (rem 2), marginBottom (rem 1.125) ] ]
                 (colors |> List.map colorElement)
     in
     styledStoriesOf

--- a/explorer/src/Stories/FilterChip.elm
+++ b/explorer/src/Stories/FilterChip.elm
@@ -1,8 +1,9 @@
 module Stories.FilterChip exposing (stories)
 
-import Css
+import Css exposing (rem)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.FilterChip as FilterChip
+import Nordea.Css exposing (gap)
 import Nordea.Html as Html
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -14,7 +15,7 @@ stories =
         "FilterChip"
         [ ( "Default"
           , \_ ->
-                Html.row [ css [ Css.property "gap" "1rem" ] ]
+                Html.row [ css [ gap (rem 1) ] ]
                     [ FilterChip.init { label = "Under behandling" }
                         |> FilterChip.view []
                     , FilterChip.init { label = "Under oppstart" }

--- a/explorer/src/Stories/Icons.elm
+++ b/explorer/src/Stories/Icons.elm
@@ -12,6 +12,7 @@ import Css
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Resources.Icons as Icons
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -24,14 +25,14 @@ stories =
             Text.bodyTextHeavy |> Text.view [] [ Html.text headerText ]
 
         iconsRow icons =
-            Html.div [ css [ displayFlex, flexDirection row, Css.property "gap" "2rem" ] ]
+            Html.div [ css [ displayFlex, flexDirection row, gap (rem 2) ] ]
                 icons
     in
     styledStoriesOf
         "Icons"
         [ ( "Icons"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, gap (rem 1) ] ]
                     [ iconCategoryHeader "Arrows and directions"
                     , iconsRow
                         [ Icons.arrowBack [ css [ width (rem 1.5) ] ]

--- a/explorer/src/Stories/Label.elm
+++ b/explorer/src/Stories/Label.elm
@@ -9,6 +9,7 @@ import Nordea.Components.Dropdown as Dropdown
 import Nordea.Components.Label as Label
 import Nordea.Components.RadioButton as RadioButton
 import Nordea.Components.TextInput as TextInput
+import Nordea.Css exposing (gap)
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -19,7 +20,7 @@ stories =
         "Label"
         [ ( "With text input"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), gap (rem 2) ] ]
                     [ Label.init "Customer name" Label.InputLabel
                         |> Label.view []
                             [ TextInput.init "Text"
@@ -70,7 +71,7 @@ stories =
           )
         , ( "With dropdown"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), gap (rem 2) ] ]
                     [ Label.init "Choose financingVariant" Label.InputLabel
                         |> Label.view []
                             [ Dropdown.init
@@ -102,7 +103,7 @@ stories =
           )
         , ( "With radio buttons"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), gap (rem 2) ] ]
                     [ Label.init "State of object" Label.GroupLabel
                         |> Label.view []
                             [ RadioButton.init
@@ -138,7 +139,7 @@ stories =
           )
         , ( "With checkboxes"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), gap (rem 2) ] ]
                     [ Label.init "State of object" Label.GroupLabel
                         |> Label.view []
                             [ Checkbox.init
@@ -204,7 +205,7 @@ stories =
           )
         , ( "Small with text input"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), gap (rem 2) ] ]
                     [ Label.init "Customer name" Label.InputLabel
                         |> Label.withSmallSize
                         |> Label.view []
@@ -234,7 +235,7 @@ stories =
           )
         , ( "Small with radio buttons"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), gap (rem 2) ] ]
                     [ Label.init "State of object" Label.GroupLabel
                         |> Label.withSmallSize
                         |> Label.view []
@@ -276,7 +277,7 @@ stories =
           )
         , ( "Small with checkboxes"
           , \_ ->
-                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), Css.property "gap" "2rem" ] ]
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), gap (rem 2) ] ]
                     [ Label.init "State of object" Label.GroupLabel
                         |> Label.withSmallSize
                         |> Label.view []

--- a/explorer/src/Stories/RadioButton.elm
+++ b/explorer/src/Stories/RadioButton.elm
@@ -1,10 +1,11 @@
 module Stories.RadioButton exposing (stories)
 
 import Config exposing (Config, Msg(..))
-import Css exposing (displayFlex)
+import Css exposing (displayFlex, rem)
 import Html.Styled as Html exposing (text)
 import Html.Styled.Attributes exposing (css, disabled)
 import Nordea.Components.RadioButton as RadioButton
+import Nordea.Css exposing (gap)
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -15,7 +16,7 @@ stories =
         "RadioButton"
         [ ( "Standard"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")
@@ -33,7 +34,7 @@ stories =
           )
         , ( "Standard with error"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")
@@ -53,7 +54,7 @@ stories =
           )
         , ( "Standard disabled"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")
@@ -71,7 +72,7 @@ stories =
           )
         , ( "Small"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "small"
                         (text "Click me")
@@ -91,7 +92,7 @@ stories =
           )
         , ( "Simple"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")
@@ -111,7 +112,7 @@ stories =
           )
         , ( "Simple with error"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")
@@ -133,7 +134,7 @@ stories =
           )
         , ( "Simple disabled"
           , \config ->
-                Html.div [ css [ displayFlex, Css.property "gap" "1rem" ] ]
+                Html.div [ css [ displayFlex, gap (rem 1) ] ]
                     [ RadioButton.init
                         "simple"
                         (text "Click me")

--- a/src/Nordea/Components/Checkbox.elm
+++ b/src/Nordea/Components/Checkbox.elm
@@ -62,6 +62,7 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attrs exposing (class, css, disabled, name, type_)
 import Html.Styled.Events exposing (onCheck)
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Html exposing (styleIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Themes as Themes
@@ -206,7 +207,7 @@ view attrs (Checkbox config) =
             case config.appearance of
                 ListStyle ->
                     Css.batch
-                        [ Css.property "gap" "0.5rem"
+                        [ gap (rem 0.5)
                         , commonNonSimpleStyles
                         , padding2 (rem 0.5) (rem 1)
                         , flexBasis (pct 100)
@@ -221,12 +222,12 @@ view attrs (Checkbox config) =
 
                 Simple ->
                     Css.batch
-                        [ Css.property "gap" "0.5rem"
+                        [ gap (rem 0.5)
                         ]
 
                 Small ->
                     Css.batch
-                        [ Css.property "gap" "0.25rem"
+                        [ gap (rem 0.25)
                         , padding4 (rem 0.25) (rem 0.5) (rem 0.25) (rem 0.25)
                         , height (rem 1.5)
                         , commonNonSimpleStyles
@@ -235,7 +236,7 @@ view attrs (Checkbox config) =
 
                 Standard ->
                     Css.batch
-                        [ Css.property "gap" "0.5rem"
+                        [ gap (rem 0.5)
                         , padding2 (rem 0.5) (rem 1)
                         , minHeight (rem 2.5)
                         , commonNonSimpleStyles

--- a/src/Nordea/Components/Coachmark.elm
+++ b/src/Nordea/Components/Coachmark.elm
@@ -65,6 +65,7 @@ import Maybe.Extra as Maybe
 import Nordea.Components.Button as Button
 import Nordea.Components.Text as Text
 import Nordea.Components.Tooltip as Tooltip
+import Nordea.Css exposing (gap)
 import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.I18N exposing (Translation)
@@ -308,14 +309,14 @@ step attrs children_ { translate, showStepLegend, onChangeStep, currentStep, tot
     in
     Html.column
         (css
-            [ Css.property "gap" "1rem"
+            [ gap (rem 1)
             , justifyContent spaceBetween
             ]
             :: attrs
         )
         [ Text.textSmallLight
             |> Text.withHtmlTag Html.row
-            |> Text.view [ css [ Css.property "gap" "1rem", alignItems flexStart ] ]
+            |> Text.view [ css [ gap (rem 1), alignItems flexStart ] ]
                 (children_
                     ++ [ Html.button
                             [ Attrs.attribute "aria-label" (translate strings.close)

--- a/src/Nordea/Components/FilterChip.elm
+++ b/src/Nordea/Components/FilterChip.elm
@@ -29,6 +29,7 @@ import Css
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Resources.Colors as Color
 import Nordea.Resources.Icons as Icon
 import Nordea.Themes as Themes
@@ -56,7 +57,7 @@ view attrs (FilterChip { label }) =
             , Themes.backgroundColor Color.cloudBlue
             , Themes.color Color.deepBlue
             , maxWidth fitContent
-            , Css.property "gap" "1rem"
+            , gap (rem 1)
             , Css.property "height" "fit-content"
             , whiteSpace noWrap
             , alignItems center

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -59,6 +59,7 @@ import Html.Styled.Events as Events
 import Json.Decode as Decode
 import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Label as Label exposing (RequirednessHint(..))
+import Nordea.Css exposing (gap)
 import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.Icons as Icon
@@ -118,7 +119,7 @@ view attrs dropdown =
                             , flexDirection row
                             , padding (rem 0.5)
                             , alignItems center
-                            , Css.property "gap" "0.5rem"
+                            , gap (rem 0.5)
                             ]
                         ]
                         [ Checkbox.init option.name (Html.text option.label) option.onCheck

--- a/src/Nordea/Components/RadioButton.elm
+++ b/src/Nordea/Components/RadioButton.elm
@@ -54,6 +54,7 @@ import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attrs exposing (css, disabled, name, type_)
 import Html.Styled.Events as Events
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Html exposing (showIf, styleIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Themes as Themes
@@ -230,7 +231,7 @@ view attrs (RadioButton config) =
     Html.label
         (css
             [ display inlineFlex
-            , Css.property "gap" "0.5rem"
+            , gap (rem 0.5)
             , alignItems center
             , boxSizing borderBox
             , position relative

--- a/src/Nordea/Components/SortableTable.elm
+++ b/src/Nordea/Components/SortableTable.elm
@@ -27,6 +27,7 @@ import Html.Styled as Html exposing (Attribute, Html, styled)
 import Html.Styled.Attributes as Attrs exposing (css)
 import Html.Styled.Events as Events
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (gap)
 import Nordea.Html
 import Nordea.Resources.Colors as Color
 import Nordea.Resources.Icons
@@ -253,7 +254,7 @@ mobileDataRow =
         , padding (rem 1.5)
         , borderRadius (rem 1)
         , backgroundColor Color.white
-        , Css.property "gap" "1rem"
+        , gap (rem 1)
         ]
 
 

--- a/src/Nordea/Css.elm
+++ b/src/Nordea/Css.elm
@@ -6,10 +6,12 @@ module Nordea.Css exposing
     , smallInputHeight
     , standardInputHeight
     , variable
-    )
+    , gap)
 
-import Css
+import Css exposing (LengthOrNoneOrMinMaxDimension)
 
+gap : LengthOrNoneOrMinMaxDimension compatible -> Css.Style
+gap length = Css.property "gap" length.value
 
 variable : String -> String -> String
 variable variableName fallback =

--- a/src/Nordea/Css.elm
+++ b/src/Nordea/Css.elm
@@ -1,17 +1,21 @@
 module Nordea.Css exposing
     ( colorToString
     , colorVariable
+    , gap
     , propertyWithColorVariable
     , propertyWithVariable
     , smallInputHeight
     , standardInputHeight
     , variable
-    , gap)
+    )
 
 import Css exposing (LengthOrNoneOrMinMaxDimension)
 
+
 gap : LengthOrNoneOrMinMaxDimension compatible -> Css.Style
-gap length = Css.property "gap" length.value
+gap length =
+    Css.property "gap" length.value
+
 
 variable : String -> String -> String
 variable variableName fallback =


### PR DESCRIPTION
Annoying and error prone to write Css.property "gap" "1rem" instead of `gap (rem 1)` like you would for height,length and such. 
This fixes that :))
Also easier to read and more in line with most other props
Copied the type from the Css-library, so it works with rem/px/pct and such

* gap (rem 1)
 <img width="540" alt="image" src="https://github.com/SGFinansAS/elm-components/assets/21218279/46a7b48e-041e-4226-8502-e24313eb26d3">
* gap (px 1)
<img width="551" alt="image" src="https://github.com/SGFinansAS/elm-components/assets/21218279/2e5ac5fa-f665-442b-b592-decf6fdf9e1f">
