### PR TITLE
Add gap2 

### DIFF
--- a/src/Nordea/Css.elm
+++ b/src/Nordea/Css.elm
@@ -2,6 +2,7 @@ module Nordea.Css exposing
     ( colorToString
     , colorVariable
     , gap
+    , gap2
     , propertyWithColorVariable
     , propertyWithVariable
     , smallInputHeight
@@ -13,8 +14,13 @@ import Css exposing (LengthOrNoneOrMinMaxDimension)
 
 
 gap : LengthOrNoneOrMinMaxDimension compatible -> Css.Style
-gap length =
-    Css.property "gap" length.value
+gap argA =
+    Css.property "gap" argA.value
+
+
+gap2 : LengthOrNoneOrMinMaxDimension compatible -> LengthOrNoneOrMinMaxDimension compatible2 -> Css.Style
+gap2 argA argB =
+    Css.property "gap" (argA.value ++ " " ++ argB.value)
 
 
 variable : String -> String -> String


### PR DESCRIPTION
Needed for things like property "gap" "0 1rem"

Basically inlining of
```
prop2 : String -> Value a -> Value b -> Style
prop2 key argA argB =
    property key (argA.value ++ " " ++ argB.value)
```

which is not exported from elm-csse