### PR TITLE
Make chat scroll to bottom by default

### DIFF
--- a/explorer/src/Stories/Chat.elm
+++ b/explorer/src/Stories/Chat.elm
@@ -19,21 +19,26 @@ stories =
                     [ Chat.init .no
                         |> Chat.view []
                             []
-                            [ Chat.chatHistoryView []
-                                { sendFrom = "Nordea Finance"
-                                , sendAt = "30.05.2024, kl. 12:26"
-                                , sender = "Line"
-                                , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
-                                , isUserMessage = False
-                                }
-                            , Chat.chatHistoryView []
-                                { sendFrom = "PartnerHub"
-                                , sendAt = "30.05.2024, kl. 13:54"
-                                , sender = "Thomas Olsen"
-                                , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
-                                , isUserMessage = True
-                                }
-                            ]
+                            (List.range 0 100
+                                |> List.concatMap
+                                    (\_ ->
+                                        [ Chat.chatHistoryView []
+                                            { sentFrom = "Nordea Finance"
+                                            , sentAt = "30.05.2024, kl. 12:26"
+                                            , sender = "Line"
+                                            , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
+                                            , isUserMessage = False
+                                            }
+                                        , Chat.chatHistoryView []
+                                            { sentFrom = "PartnerHub"
+                                            , sentAt = "30.05.2024, kl. 13:54"
+                                            , sender = "Thomas Olsen"
+                                            , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
+                                            , isUserMessage = True
+                                            }
+                                        ]
+                                    )
+                            )
                             [ Text.textSmallLight |> Text.view [] [ Html.text "Some chat content" ]
                             ]
                     ]
@@ -43,24 +48,29 @@ stories =
           , \_ ->
                 Html.div [ css [ maxWidth (rem 25) ] ]
                     [ Chat.init .no
-                        |> Chat.view [ Chat.Appearance Chat.Small ]
+                        |> Chat.view []
                             []
-                            [ Chat.chatHistoryView []
-                                { sendFrom = "Nordea Finance"
-                                , sendAt = "30.05.2024, kl. 12:26"
-                                , sender = "Line"
-                                , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
-                                , isUserMessage = True
-                                }
-                            , Chat.chatHistoryView []
-                                { sendFrom = "PartnerHub"
-                                , sendAt = "30.05.2024, kl. 13:54"
-                                , sender = "Thomas Olsen"
-                                , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
-                                , isUserMessage = False
-                                }
-                            ]
-                            [ Text.textTinyLight |> Text.view [] [ Html.text "Some chat content" ]
+                            (List.range 0 100
+                                |> List.concatMap
+                                    (\_ ->
+                                        [ Chat.chatHistoryView []
+                                            { sentFrom = "Nordea Finance"
+                                            , sentAt = "30.05.2024, kl. 12:26"
+                                            , sender = "Line"
+                                            , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
+                                            , isUserMessage = False
+                                            }
+                                        , Chat.chatHistoryView []
+                                            { sentFrom = "PartnerHub"
+                                            , sentAt = "30.05.2024, kl. 13:54"
+                                            , sender = "Thomas Olsen"
+                                            , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
+                                            , isUserMessage = True
+                                            }
+                                        ]
+                                    )
+                            )
+                            [ Text.textSmallLight |> Text.view [] [ Html.text "Some chat content" ]
                             ]
                     ]
           , {}

--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -7,6 +7,8 @@ import Css
         , border3
         , borderRadius4
         , color
+        , columnReverse
+        , flexDirection
         , flexEnd
         , justifyContent
         , marginBottom
@@ -15,7 +17,6 @@ import Css
         , overflow
         , padding
         , paddingRight
-        , px
         , rem
         , solid
         , spaceBetween
@@ -40,8 +41,8 @@ type alias Config =
 
 
 type alias MessageViewConfig =
-    { sendFrom : String
-    , sendAt : String
+    { sentFrom : String
+    , sentAt : String
     , sender : String
     , message : String
     , isUserMessage : Bool
@@ -116,21 +117,28 @@ view optionals attrs history content (Chat config) =
                             gap (rem 0.5)
             in
             Html.column
-                [ css [ gapStyle, maxHeight (px 500), overflow auto, paddingRight (rem 0.3125) ]
+                [ css
+                    [ gapStyle
+                    , maxHeight (rem 32)
+                    , overflow auto
+                    , paddingRight (rem 0.3125)
+                    , flexDirection columnReverse |> Css.important
+                    ]
                 ]
-                history
+                [ Html.div [] history ]
                 |> showIf (not (List.isEmpty history))
     in
     Card.init
         |> Card.view (css appearanceSpecificStyles :: attrs)
             [ headerView
             , messageHistoryView
-            , Html.column [ css [ gap (rem 0.5) ] ] content |> showIf (not (List.isEmpty content))
+            , Html.column [ css [ gap (rem 0.5) ] ] content
+                |> showIf (not (List.isEmpty content))
             ]
 
 
 chatHistoryView : List (Attribute msg) -> MessageViewConfig -> Html msg
-chatHistoryView attrs { sendFrom, sendAt, sender, message, isUserMessage } =
+chatHistoryView attrs { sentFrom, sentAt, sender, message, isUserMessage } =
     let
         messageStyles =
             if isUserMessage then
@@ -150,8 +158,8 @@ chatHistoryView attrs { sendFrom, sendAt, sender, message, isUserMessage } =
     in
     Html.column (css [ gap (rem 0.25) ] :: attrs)
         [ Html.row [ css [ justifyContent spaceBetween ] ]
-            [ messageLabel sendFrom
-            , messageLabel sendAt
+            [ messageLabel sentFrom
+            , messageLabel sentAt
             ]
         , Text.textTinyHeavy
             |> Text.view [] [ Html.text sender ]


### PR DESCRIPTION
Minor fix to get the chat to scroll to bottom by default. So that the user doesnt have to scroll manually when writing a msg.

This is a css only solution using `flex-direction: column-reverse`. See https://stackoverflow.com/a/44051405