### PR TITLE
Add a unified FileUpload view for single file uploads

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
         "elm-community/list-extra": "8.2.4 <= v < 9.0.0",
         "elm-community/maybe-extra": "5.2.0 <= v < 6.0.0",
         "justinmimbs/date": "3.2.1 <= v < 5.0.0",
+        "krisajenkins/remotedata": "6.0.1 <= v < 7.0.0",
         "myrho/elm-round": "1.0.4 <= v < 2.0.0",
         "rtfeldman/elm-css": "16.1.0 <= v < 19.0.0"
     },

--- a/explorer/elm.json
+++ b/explorer/elm.json
@@ -17,6 +17,7 @@
             "elm-community/maybe-extra": "5.3.0",
             "justinmimbs/date": "3.2.1",
             "kalutheo/elm-ui-explorer": "9.1.0",
+            "krisajenkins/remotedata": "6.0.1",
             "myrho/elm-round": "1.0.5",
             "rtfeldman/elm-css": "16.1.1"
         },
@@ -26,6 +27,7 @@
             "avh4/elm-debug-controls": "2.2.1",
             "elm/browser": "1.0.2",
             "elm/bytes": "1.0.8",
+            "elm/http": "2.0.0",
             "elm/parser": "1.1.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -72,7 +72,7 @@ type Msg
     | ToggleProgressBarCompleted
     | OnDragEnterFileUpload
     | OnDragLeaveFileUpload
-    | OnFilesSelected File (List File)
+    | OnFilesSelected (List File)
     | RemoveFile File
     | SliderMsg String
     | RangeMsg Float
@@ -189,8 +189,8 @@ update msg config =
         OnDragLeaveFileUpload ->
             { config | isHoveringFileUpload = False }
 
-        OnFilesSelected first rest ->
-            { config | selectedFiles = (first :: rest) ++ config.selectedFiles, isHoveringFileUpload = False }
+        OnFilesSelected files ->
+            { config | selectedFiles = files ++ config.selectedFiles, isHoveringFileUpload = False }
 
         RemoveFile file ->
             { config | selectedFiles = config.selectedFiles |> List.filter ((/=) file) }

--- a/explorer/src/Stories/FileUpload.elm
+++ b/explorer/src/Stories/FileUpload.elm
@@ -6,7 +6,9 @@ import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.FileUpload as FileUpload
 import Nordea.Components.Label as Label
+import Nordea.Css exposing (gap)
 import Nordea.Html exposing (showIf)
+import RemoteData
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
@@ -32,6 +34,28 @@ stories =
                             ]
                     , FileUpload.uploadedFilesView model.customModel.selectedFiles RemoveFile .no [ css [ marginTop (rem 1) ] ]
                         |> showIf (not (List.isEmpty model.customModel.selectedFiles))
+                    ]
+          , {}
+          )
+        , ( "Large (Single file, unified view)"
+          , \model ->
+                let
+                    container remoteText remote =
+                        Label.init ("Some file document: " ++ remoteText) Label.InputLabel
+                            |> Label.withRequirednessHint (Just (Label.Optional .no))
+                            |> Label.view []
+                                [ FileUpload.init .no OnFilesSelected OnDragEnterFileUpload OnDragLeaveFileUpload
+                                    |> FileUpload.withIsHovering model.customModel.isHoveringFileUpload
+                                    |> FileUpload.withAcceptedFileTypes supportedFileTypes
+                                    |> FileUpload.withFiles (model.customModel.selectedFiles |> List.map (\f -> ( f, remote ))) RemoveFile
+                                    |> FileUpload.view
+                                ]
+                in
+                Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 30), gap (rem 2) ] ]
+                    [ container "NotAsked" <| RemoteData.NotAsked
+                    , container "Loading" <| RemoteData.Loading
+                    , container "Success" <| RemoteData.Success ()
+                    , container "Failure" <| RemoteData.Failure { se = "Fel", no = "Feil", dk = "Feil", en = "Error" }
                     ]
           , {}
           )

--- a/src/Nordea/Components/FileUpload.elm
+++ b/src/Nordea/Components/FileUpload.elm
@@ -2,6 +2,7 @@ module Nordea.Components.FileUpload exposing
     ( AcceptFileType(..)
     , Appearance(..)
     , FileUpload
+    , FileUploadStatus
     , MimeType(..)
     , init
     , supportedFileTypesText
@@ -10,57 +11,27 @@ module Nordea.Components.FileUpload exposing
     , withAcceptedFileTypes
     , withAllowMultipleFiles
     , withAppearance
+    , withFiles
     , withIsHovering
     )
 
-import Css
-    exposing
-        ( absolute
-        , alignItems
-        , backgroundColor
-        , border3
-        , borderRadius
-        , borderStyle
-        , center
-        , color
-        , column
-        , cursor
-        , dashed
-        , displayFlex
-        , flex
-        , flexDirection
-        , height
-        , hover
-        , justifyContent
-        , listStyle
-        , listStyleType
-        , margin2
-        , marginBottom
-        , marginRight
-        , marginTop
-        , none
-        , num
-        , opacity
-        , padding
-        , padding2
-        , pointer
-        , position
-        , pseudoClass
-        , rem
-        , row
-        , width
-        )
+import Css exposing (absolute, alignItems, backgroundColor, border3, borderRadius, borderStyle, borderWidth, center, color, column, cursor, dashed, default, displayFlex, flex, flexDirection, height, hover, inherit, justifyContent, left, listStyle, listStyleType, margin2, marginBottom, marginRight, marginTop, none, num, opacity, padding, padding2, pct, pointer, position, pseudoClass, px, relative, rem, row, top, width)
+import Css.Global as Global
 import File exposing (File)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (accept, css, multiple, type_, value)
 import Html.Styled.Events as Events
 import Json.Decode as Decode
+import Maybe.Extra as Maybe
+import Nordea.Components.Spinner as Spinner
 import Nordea.Components.Text as Text
+import Nordea.Components.Tooltip as Tooltip
 import Nordea.Html as Html exposing (showIf, styleIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.I18N exposing (Translation)
 import Nordea.Resources.Icons as Icon
 import Nordea.Themes as Themes
+import RemoteData exposing (RemoteData)
 import Round
 
 
@@ -89,20 +60,25 @@ type FileUpload msg
     = FileUpload (Config msg)
 
 
+type alias FileUploadStatus =
+    RemoteData Translation ()
+
+
 type alias Config msg =
     { isHovering : Bool
     , onDragEnter : msg
     , onDragLeave : msg
-    , files : List File
+    , files : List ( File, FileUploadStatus )
     , translate : Translate
     , allowMultiple : Bool
-    , onFilesSelected : File -> List File -> msg
+    , onFilesSelected : List File -> msg
+    , onFileRemoval : Maybe (File -> msg)
     , accept : AcceptFileType
     , appearance : Appearance
     }
 
 
-init : Translate -> (File -> List File -> msg) -> msg -> msg -> FileUpload msg
+init : Translate -> (List File -> msg) -> msg -> msg -> FileUpload msg
 init translate onFilesSelected onDragEnter onDragLeave =
     FileUpload
         { isHovering = False
@@ -112,6 +88,7 @@ init translate onFilesSelected onDragEnter onDragLeave =
         , translate = translate
         , allowMultiple = False
         , onFilesSelected = onFilesSelected
+        , onFileRemoval = Nothing
         , accept = Any
         , appearance = Large
         }
@@ -159,27 +136,12 @@ view (FileUpload config) =
                             , hover [ backgroundColor Colors.coolGray ]
                             ]
             in
-            [ onFilesDropped
-                config.accept
-                (\first rest ->
-                    config.onFilesSelected
-                        first
-                        (if config.allowMultiple then
-                            rest
-
-                         else
-                            []
-                        )
-                )
-            , preventDefaultOn "dragover" config.onDragEnter
-            , preventDefaultOn "dragleave" config.onDragLeave
-            , css
+            [ css
                 [ displayFlex
                 , styleAppearance
                 , alignItems center
                 , borderRadius (rem 0.25)
                 , cursor pointer
-                , pseudoClass "focus-within" [ border3 (rem 0.0625) dashed Colors.deepBlue ]
                 , styleOnHover
                 ]
             ]
@@ -242,30 +204,87 @@ view (FileUpload config) =
                     mimeTypes
                         |> List.map toMimeTypeString
                         |> String.join ","
+
+        inputFile =
+            Html.input
+                [ type_ "file"
+                , onSelectFiles config.accept config.onFilesSelected
+                , multiple config.allowMultiple
+                , accept mimeTypesAsString
+                , value ""
+                , css [ opacity (num 0), position absolute, height (rem 0), width (rem 0) ]
+                ]
+                []
+                |> showIf (config.allowMultiple || List.isEmpty config.files)
     in
-    Html.div attrs
-        [ iconUpload |> showIf (not config.isHovering)
-        , description |> showIf (not config.isHovering)
-        , viewSupportedFileTypesText
-            |> showIf (not config.isHovering && config.appearance == Large)
-        , textType
-            |> Text.view [ css [ Themes.color Colors.nordeaBlue ] ]
-                [ Html.text (config.translate strings.dropToUploadFile) ]
-            |> showIf config.isHovering
-        , Html.input
-            [ type_ "file"
-            , onSelectFiles config.onFilesSelected
-            , multiple config.allowMultiple
-            , accept mimeTypesAsString
-            , value ""
-            , css [ opacity (num 0), position absolute, height (rem 0), width (rem 0) ]
-            ]
-            []
-        ]
+    -- Inline is currently only supported with one file; feel free to enhance :)
+    config.onFileRemoval
+        |> Maybe.filter (\_ -> not config.allowMultiple && (List.isEmpty config.files |> not) && config.appearance == Large)
+        |> Maybe.map
+            (\onFileRemoval ->
+                fileList
+                    config.files
+                    onFileRemoval
+                    config.translate
+                    (attrs
+                        ++ [ css
+                                [ borderWidth (px 0) |> Css.important
+                                , cursor default |> Css.important
+                                , Global.children [ Global.typeSelector ":first-child" [ height inherit, width (pct 100) ] ]
+
+                                -- 2024-08-22 Elm css first-child is b0rken! ^
+                                ]
+                           ]
+                    )
+            )
+        |> Maybe.withDefault
+            (Html.div
+                (attrs
+                    ++ [ css [ pseudoClass "focus-within" [ border3 (rem 0.0625) dashed Colors.deepBlue ] ]
+                       , onFilesDropped
+                            config.accept
+                            (\files ->
+                                config.onFilesSelected
+                                    (if config.allowMultiple then
+                                        files
+
+                                     else
+                                        files |> List.take 1
+                                    )
+                            )
+                       , preventDefaultOn "dragover" config.onDragEnter
+                       , preventDefaultOn "dragleave" config.onDragLeave
+                       ]
+                )
+                [ iconUpload |> showIf (not config.isHovering)
+                , description |> showIf (not config.isHovering)
+                , viewSupportedFileTypesText
+                    |> showIf (not config.isHovering && config.appearance == Large)
+                , textType
+                    |> Text.view [ css [ Themes.color Colors.nordeaBlue ] ]
+                        [ Html.text (config.translate strings.dropToUploadFile) ]
+                    |> showIf config.isHovering
+                , inputFile
+                ]
+            )
 
 
 uploadedFilesView : List File -> (File -> msg) -> Translate -> List (Attribute msg) -> Html msg
 uploadedFilesView files onClickRemove translate attrs =
+    Html.section attrs
+        [ Text.textSmallLight
+            |> Text.withHtmlTag Html.h1
+            |> Text.view [ css [ marginBottom (rem 0.25) ] ] [ Html.text (translate strings.uploadedFiles) ]
+        , fileList
+            (files |> List.map (\f -> ( f, RemoteData.NotAsked )))
+            onClickRemove
+            translate
+            []
+        ]
+
+
+fileList : List ( File, FileUploadStatus ) -> (File -> msg) -> Translate -> List (Attribute msg) -> Html msg
+fileList files onClickRemove translate attrs =
     let
         fileSizeToString fileSize =
             if fileSize < 1000 then
@@ -287,49 +306,70 @@ uploadedFilesView files onClickRemove translate attrs =
                     |> Round.round 2
                     |> String.replace "." ","
                     |> (\str -> str ++ " GB")
-    in
-    Html.section attrs
-        [ Text.textSmallLight
-            |> Text.withHtmlTag Html.h1
-            |> Text.view [ css [ marginBottom (rem 0.25) ] ] [ Html.text (translate strings.uploadedFiles) ]
-        , Html.ul [ css [ listStyleType none, padding (rem 0) ] ]
-            (files
-                |> List.map
-                    (\file ->
-                        Html.li
-                            [ css
-                                [ displayFlex
-                                , alignItems center
-                                , listStyle none
-                                , padding2 (rem 0.75) (rem 1.25)
-                                , backgroundColor Colors.coolGray
-                                , borderRadius (rem 0.5)
-                                , pseudoClass "not(:last-child)" [ marginBottom (rem 1) ]
-                                ]
+
+        statusOverlay status =
+            (case status of
+                RemoteData.NotAsked ->
+                    Html.nothing
+
+                RemoteData.Loading ->
+                    Spinner.custom [ css [ color Colors.nordeaBlue, width (rem 2) ] ]
+
+                RemoteData.Success _ ->
+                    Html.nothing
+
+                RemoteData.Failure translation ->
+                    Tooltip.init
+                        |> Tooltip.withContent
+                            (Tooltip.infoTooltip [] [ translation |> translate |> Html.text ])
+                        |> Tooltip.view []
+                            [ Icon.warning
+                                [ css [ backgroundColor Colors.redStatus, borderRadius (pct 50), width (rem 2) ] ]
                             ]
-                            [ Icon.pdf [ css [ color Colors.black, marginRight (rem 1) ] ]
-                            , Html.div [ css [ displayFlex, flexDirection column, flex (num 1), marginRight (rem 1) ] ]
-                                [ Text.bodyTextSmall
-                                    |> Text.view [] [ Html.text (File.name file) ]
-                                , Text.textTinyLight
-                                    |> Text.view [] [ file |> File.size |> fileSizeToString |> Html.text ]
-                                ]
-                            , Html.button
-                                [ preventDefaultOn "click" (onClickRemove file)
-                                , css
-                                    [ borderStyle none
-                                    , Css.property "appearance" "none"
-                                    , cursor pointer
-                                    , padding2 (rem 0.75) (rem 1.25)
-                                    , margin2 (rem -0.75) (rem -1.25)
-                                    , backgroundColor Colors.transparent
-                                    ]
-                                ]
-                                [ Icon.trash [ css [ Themes.color Colors.deepBlue ] ] ]
-                            ]
-                    )
             )
-        ]
+                |> List.singleton
+    in
+    Html.ul (css [ listStyleType none, padding (rem 0) ] :: attrs)
+        (files
+            |> List.map
+                (\( file, status ) ->
+                    Html.li
+                        [ css
+                            [ displayFlex
+                            , alignItems center
+                            , listStyle none
+                            , padding2 (rem 0.75) (rem 1.25)
+                            , backgroundColor Colors.coolGray
+                            , borderRadius (rem 0.5)
+                            , pseudoClass "not(:last-child)" [ marginBottom (rem 1) ]
+                            ]
+                        ]
+                        [ Html.div [ css [ position relative ] ]
+                            [ Html.div [ css [ position absolute, top (rem -0.4), left (rem -0.45) ] ]
+                                (statusOverlay status)
+                            , Icon.pdf [ css [ color Colors.black, marginRight (rem 1) ] ]
+                            ]
+                        , Html.div [ css [ displayFlex, flexDirection column, flex (num 1), marginRight (rem 1) ] ]
+                            [ Text.bodyTextSmall
+                                |> Text.view [] [ Html.text (File.name file) ]
+                            , Text.textTinyLight
+                                |> Text.view [] [ file |> File.size |> fileSizeToString |> Html.text ]
+                            ]
+                        , Html.button
+                            [ preventDefaultOn "click" (onClickRemove file)
+                            , css
+                                [ borderStyle none
+                                , Css.property "appearance" "none"
+                                , cursor pointer
+                                , padding2 (rem 0.75) (rem 1.25)
+                                , margin2 (rem -0.75) (rem -1.25)
+                                , backgroundColor Colors.transparent
+                                ]
+                            ]
+                            [ Icon.trash [ css [ Themes.color Colors.deepBlue ] ] ]
+                        ]
+                )
+        )
 
 
 supportedFileTypesText : Translate -> AcceptFileType -> Maybe String
@@ -385,29 +425,33 @@ withAppearance appearance (FileUpload config) =
     FileUpload { config | appearance = appearance }
 
 
-onFilesDropped : AcceptFileType -> (File -> List File -> msg) -> Attribute msg
+withFiles : List ( File, FileUploadStatus ) -> (File -> msg) -> FileUpload msg -> FileUpload msg
+withFiles files onFileRemoval (FileUpload config) =
+    FileUpload
+        { config
+            | files = files
+            , onFileRemoval = Just onFileRemoval
+        }
+
+
+filterFiles : AcceptFileType -> List File -> List File
+filterFiles acceptFileType files =
+    case acceptFileType of
+        Any ->
+            files
+
+        Only mimeTypes ->
+            files |> List.filter (\file -> List.member (File.mime file) (List.map toMimeTypeString mimeTypes))
+
+
+onFilesDropped : AcceptFileType -> (List File -> msg) -> Attribute msg
 onFilesDropped acceptFileType msg =
     let
         filesDroppedDecoder =
             Decode.at [ "dataTransfer", "files" ] (Decode.list File.decoder)
-                |> Decode.map
-                    (\files ->
-                        case acceptFileType of
-                            Any ->
-                                files
-
-                            Only mimeTypes ->
-                                files |> List.filter (\file -> List.member (File.mime file) (List.map toMimeTypeString mimeTypes))
-                    )
+                |> Decode.map (filterFiles acceptFileType)
                 |> Decode.andThen
-                    (\files ->
-                        case files of
-                            head :: tail ->
-                                Decode.succeed ( msg head tail, True )
-
-                            _ ->
-                                Decode.fail "No files selected"
-                    )
+                    (\files -> Decode.succeed ( msg files, True ))
     in
     Events.preventDefaultOn "drop" filesDroppedDecoder
 
@@ -417,20 +461,14 @@ preventDefaultOn event msg =
     Events.preventDefaultOn event (Decode.succeed ( msg, True ))
 
 
-onSelectFiles : (File -> List File -> msg) -> Attribute msg
-onSelectFiles msg =
+onSelectFiles : AcceptFileType -> (List File -> msg) -> Attribute msg
+onSelectFiles acceptFileType msg =
     let
         filesDecoder =
             Decode.at [ "target", "files" ] (Decode.list File.decoder)
+                |> Decode.map (filterFiles acceptFileType)
                 |> Decode.andThen
-                    (\files ->
-                        case files of
-                            head :: tail ->
-                                Decode.succeed (msg head tail)
-
-                            _ ->
-                                Decode.fail "No files selected"
-                    )
+                    (\files -> Decode.succeed (msg files))
     in
     Events.on "change" filesDecoder
 

--- a/src/Nordea/Html.elm
+++ b/src/Nordea/Html.elm
@@ -11,6 +11,7 @@ module Nordea.Html exposing
     )
 
 import Css exposing (Style, displayFlex, flexDirection, flexWrap, wrap)
+import Html.Attributes.Extra as Attributes
 import Html.Styled as Html exposing (Attribute, Html, div, styled)
 import Html.Styled.Attributes as Attributes
 
@@ -86,9 +87,10 @@ styleIf condition style =
         Css.property "_" "_"
 
 
+attrIf : Bool -> Attribute msg -> Attribute msg
 attrIf condition attr =
     if condition then
         attr
 
     else
-        Attributes.attribute "" ""
+        Attributes.empty |> Attributes.fromUnstyled


### PR DESCRIPTION
- Adds a unified FileUpload view for single file uploads (with RemoteData for upload state) .
- This also fixes a bug where Decode errors out when added files were not on the accepted list - allowing the drop event to bubble to the top, showing the file contents in the browser.
-  Still not 100% compatible with CP design docs; need to discuss cross-team that all have the same design req.

Breaks API: onFilesSelected handler gives a List that can be empty.

## After file add
![image](https://github.com/user-attachments/assets/560c1f45-ec36-43e8-bef1-43d559f5fb3e)
