### PR TITLE
Add some spacing to the label requireness hint

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -43,6 +43,7 @@ import Css.Global exposing (descendants, everything, selector, typeSelector)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (class, css)
 import Nordea.Components.Text as Text
+import Nordea.Css exposing (columnGap)
 import Nordea.Html as Html exposing (showIf)
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.I18N exposing (Translation)
@@ -126,6 +127,7 @@ view attrs children (Label config) =
                 [ css
                     [ justifyContent spaceBetween
                     , marginBottom (rem 0.2)
+                    , columnGap (rem 1)
                     ]
                 ]
                 [ initText config.size


### PR DESCRIPTION
- Small screens that need to squeeze the labels will otherwise have the hint too close to the label.
Before:
![image](https://github.com/user-attachments/assets/a3265ce7-dd7a-4d0c-a04a-3d7c7f8c8126)
After:
![image](https://github.com/user-attachments/assets/e3898817-b9c4-406b-9035-35c579eef9ed)
