### PR TITLE
Make chat sender optional

### DIFF
--- a/explorer/src/Stories/Chat.elm
+++ b/explorer/src/Stories/Chat.elm
@@ -25,14 +25,14 @@ stories =
                                         [ Chat.chatHistoryView []
                                             { sentFrom = "Nordea Finance"
                                             , sentAt = "30.05.2024, kl. 12:26"
-                                            , sender = "Line"
+                                            , sender = Nothing
                                             , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
                                             , isUserMessage = False
                                             }
                                         , Chat.chatHistoryView []
                                             { sentFrom = "PartnerHub"
                                             , sentAt = "30.05.2024, kl. 13:54"
-                                            , sender = "Thomas Olsen"
+                                            , sender = Just "Thomas Olsen"
                                             , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
                                             , isUserMessage = True
                                             }
@@ -56,14 +56,14 @@ stories =
                                         [ Chat.chatHistoryView []
                                             { sentFrom = "Nordea Finance"
                                             , sentAt = "30.05.2024, kl. 12:26"
-                                            , sender = "Line"
+                                            , sender = Just "Line"
                                             , message = "I forbindelse med deres søknad om finansiering gjennom oss ønsker vi innsikt i deres 2023-tall. Kan du oversende disse? Resultat- og balanserapport."
                                             , isUserMessage = False
                                             }
                                         , Chat.chatHistoryView []
                                             { sentFrom = "PartnerHub"
                                             , sentAt = "30.05.2024, kl. 13:54"
-                                            , sender = "Thomas Olsen"
+                                            , sender = Just "Thomas Olsen"
                                             , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."
                                             , isUserMessage = True
                                             }

--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -43,7 +43,7 @@ type alias Config =
 type alias MessageViewConfig =
     { sentFrom : String
     , sentAt : String
-    , sender : String
+    , sender : Maybe String
     , message : String
     , isUserMessage : Bool
     }
@@ -163,8 +163,13 @@ chatHistoryView attrs { sentFrom, sentAt, sender, message, isUserMessage } =
             [ messageLabel sentFrom
             , messageLabel sentAt
             ]
-        , Text.textTinyHeavy
-            |> Text.view [] [ Html.text sender ]
+        , sender
+            |> Maybe.map
+                (\sender_ ->
+                    Text.textTinyHeavy
+                        |> Text.view [] [ Html.text sender_ ]
+                )
+            |> Maybe.withDefault Html.nothing
         , Text.textSmallLight
             |> Text.view
                 [ css (padding (rem 0.625) :: messageStyles) ]


### PR DESCRIPTION
In some cases we might not want to show the sender name and only show the message channel. So changed sender to option type.

![image](https://github.com/user-attachments/assets/7bd81598-a936-47f4-aa0a-32e80e0e0138)
