### PR TITLE
Accordion table components

### DIFF
--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -1,6 +1,7 @@
 module Config exposing (Config, FinancingVariant(..), Msg(..), OrganizationInfo, init, update)
 
 import Date
+import Set exposing (Set)
 import File exposing (File)
 import Html.Styled as Html
 import Nordea.Components.Accordion as Accordion exposing (Accordion)
@@ -28,6 +29,7 @@ type alias OrganizationInfo =
 
 type alias Config =
     { accordion : Accordion
+    , openAccordionTableRows : Set Int
     , isModalOpen : Bool
     , searchComponentInput : String
     , hasMultiSelectDropdownFocus : Bool
@@ -58,6 +60,7 @@ type alias Config =
 
 type Msg
     = AccordionMsg Accordion.Msg
+    | AccordionTableMsg Int Bool
     | SearchComponentInput String
     | SearchComponentSelected (Maybe (Item FinancingVariant))
     | SearchComponentSelectedOrgInfo (Maybe (Item OrganizationInfo))
@@ -105,6 +108,7 @@ init =
                 , body = [ Html.text "This is an answer" ]
                 , open = False
                 }
+    , openAccordionTableRows = Set.empty
     , searchComponentInput = ""
     , selectedSearchComponent = Nothing
     , selectedSearchComponentOrgInfo = Nothing
@@ -138,6 +142,16 @@ update msg config =
     case msg of
         AccordionMsg m ->
             { config | accordion = Accordion.update m config.accordion }
+
+        AccordionTableMsg index isOpen ->
+            let
+                operation =
+                    if isOpen then
+                        Set.insert
+                    else
+                        Set.remove
+            in
+            { config | openAccordionTableRows = operation index config.openAccordionTableRows  }
 
         SearchComponentInput input ->
             { config | searchComponentInput = input }

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -1,12 +1,12 @@
 module Config exposing (Config, FinancingVariant(..), Msg(..), OrganizationInfo, init, update)
 
 import Date
-import Set exposing (Set)
 import File exposing (File)
 import Html.Styled as Html
 import Nordea.Components.Accordion as Accordion exposing (Accordion)
 import Nordea.Components.DatePicker as DatePicker exposing (DatePicker)
 import Nordea.Components.DropdownFilter exposing (Item)
+import Set exposing (Set)
 import Stories.SortableTableSharedTypes
 import Time exposing (Month(..))
 
@@ -148,10 +148,11 @@ update msg config =
                 operation =
                     if isOpen then
                         Set.insert
+
                     else
                         Set.remove
             in
-            { config | openAccordionTableRows = operation index config.openAccordionTableRows  }
+            { config | openAccordionTableRows = operation index config.openAccordionTableRows }
 
         SearchComponentInput input ->
             { config | searchComponentInput = input }

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -30,6 +30,7 @@ type alias OrganizationInfo =
 type alias Config =
     { accordion : Accordion
     , openAccordionTableRows : Set Int
+    , selectedAccordionTableRows : Set Int
     , isModalOpen : Bool
     , searchComponentInput : String
     , hasMultiSelectDropdownFocus : Bool
@@ -60,7 +61,9 @@ type alias Config =
 
 type Msg
     = AccordionMsg Accordion.Msg
-    | AccordionTableMsg Int Bool
+    | AccordionTableRowToggled Int Bool
+    | AccordionTableAllRowsChecked Bool
+    | AccordionTableRowChecked Int Bool
     | SearchComponentInput String
     | SearchComponentSelected (Maybe (Item FinancingVariant))
     | SearchComponentSelectedOrgInfo (Maybe (Item OrganizationInfo))
@@ -109,6 +112,7 @@ init =
                 , open = False
                 }
     , openAccordionTableRows = Set.empty
+    , selectedAccordionTableRows = Set.empty
     , searchComponentInput = ""
     , selectedSearchComponent = Nothing
     , selectedSearchComponentOrgInfo = Nothing
@@ -143,7 +147,7 @@ update msg config =
         AccordionMsg m ->
             { config | accordion = Accordion.update m config.accordion }
 
-        AccordionTableMsg index isOpen ->
+        AccordionTableRowToggled index isOpen ->
             let
                 operation =
                     if isOpen then
@@ -153,6 +157,27 @@ update msg config =
                         Set.remove
             in
             { config | openAccordionTableRows = operation index config.openAccordionTableRows }
+
+        AccordionTableAllRowsChecked areChecked ->
+            { config
+                | selectedAccordionTableRows =
+                    if areChecked then
+                        Set.fromList [ 0, 1 ]
+
+                    else
+                        Set.empty
+            }
+
+        AccordionTableRowChecked index isChecked ->
+            let
+                operation =
+                    if isChecked then
+                        Set.insert
+
+                    else
+                        Set.remove
+            in
+            { config | selectedAccordionTableRows = operation index config.selectedAccordionTableRows }
 
         SearchComponentInput input ->
             { config | searchComponentInput = input }

--- a/explorer/src/Explorer.elm
+++ b/explorer/src/Explorer.elm
@@ -6,6 +6,7 @@ import Html.Styled exposing (toUnstyled)
 import Nordea.Resources.Fonts.Fonts as Fonts
 import Stories.Accordion as Accordion
 import Stories.AccordionMenu as AccordionMenu
+import Stories.AccordionTable as AccordionTable
 import Stories.Badge as Badge
 import Stories.Button as Button
 import Stories.Card as Card
@@ -95,6 +96,7 @@ main =
             |> UIExplorer.category "Components"
                 [ Accordion.stories
                 , AccordionMenu.stories
+                , AccordionTable.stories
                 , Badge.stories
                 , Button.stories
                 , Card.stories

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -1,7 +1,7 @@
 module Stories.AccordionTable exposing (stories)
 
 import Config exposing (Config, Msg)
-import Css exposing (color, display, marginLeft, marginTop, maxWidth, padding, px, rem)
+import Css exposing (color, marginLeft, marginTop, maxWidth, px, rem)
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (attribute, css)
 import Json.Encode as Encode

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -1,13 +1,15 @@
 module Stories.AccordionTable exposing (stories)
 
 import Config exposing (Config, Msg)
-import Css exposing (color, marginBottom, marginLeft, marginTop, maxWidth, px, rem)
+import Css exposing (color, display, marginLeft, marginTop, maxWidth, padding, px, rem)
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.AccordionTableHeader as Header
 import Nordea.Components.AccordionTableRow as Row
+import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Text as Text
-import Nordea.Css exposing (displayGrid, gridColumn, gridTemplateColumns)
+import Nordea.Css exposing (displayGrid, gap2, gridColumn, gridTemplateColumns)
+import Nordea.Html exposing (nothing)
 import Nordea.Resources.Colors as Colors
 import Set
 import UIExplorer exposing (UI)
@@ -25,11 +27,11 @@ stories =
                         |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
                             [ Text.textLight |> Text.view [] [ text "Table header" ] ]
-                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some summary" ] ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
                         |> Row.view []
-                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 1)
                         |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some other summary" ] ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "More details" ] ]
                         |> Row.view []
@@ -48,7 +50,7 @@ stories =
                         , Text.textLight |> Text.view [] [ text "Occupation" ]
                         , Text.textLight |> Text.view [] [ text "Age" ]
                         ]
-                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Johnny" ]
                             , Text.textLight |> Text.view [] [ text "Carpenter" ]
@@ -56,13 +58,48 @@ stories =
                             ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details about Johnny" ] ]
                         |> Row.view []
-                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 1)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Maximilian" ]
                             , Text.textLight |> Text.view [] [ text "Musician" ]
                             , Text.textLight |> Text.view [] [ text "23" ]
                             ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details about Maximilian" ] ]
+                        |> Row.view []
+                    ]
+          , {}
+          )
+        , ( "Selectable rows"
+          , \config ->
+                div [ css [ displayGrid, gridTemplateColumns "1fr auto auto", gap2 (rem 0) (rem 1), maxWidth (px 800) ] ]
+                    [ Header.init
+                        |> Header.view
+                            [ css [ displayGrid, gridTemplateColumns "subgrid", color Colors.cloudBlue, padding (rem 1) ] ]
+                            [ Text.textLight |> Text.view [] [ text "Selectable rows" ]
+                            , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableAllRowsChecked checked)
+                                |> Checkbox.withAppearance Checkbox.Simple
+                                |> Checkbox.withIsChecked (Set.size config.customModel.selectedAccordionTableRows == 2)
+                                |> Checkbox.view []
+                            ]
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
+                        |> Row.withSummary []
+                            [ Text.textLight |> Text.view [] [ text "Some summary" ]
+                            , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableRowChecked 0 checked)
+                                |> Checkbox.withAppearance Checkbox.Simple
+                                |> Checkbox.withIsChecked (Set.member 0 config.customModel.selectedAccordionTableRows)
+                                |> Checkbox.view []
+                            ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
+                        |> Row.view []
+                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 1)
+                        |> Row.withSummary []
+                            [ Text.textLight |> Text.view [] [ text "Some other summary" ]
+                            , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableRowChecked 1 checked)
+                                |> Checkbox.withAppearance Checkbox.Simple
+                                |> Checkbox.withIsChecked (Set.member 1 config.customModel.selectedAccordionTableRows)
+                                |> Checkbox.view []
+                            ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "More details" ] ]
                         |> Row.view []
                     ]
           , {}
@@ -75,7 +112,7 @@ stories =
                         |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
                             [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
-                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSmallSize
                         |> Row.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]
                         |> Row.withDetails [] [ Text.textSmallLight |> Text.view [] [ text "Details" ] ]

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -39,6 +39,10 @@ stories =
           )
         , ( "Multiple columns"
           , \config ->
+                let
+                    isOpen index =
+                        Set.member index config.customModel.openAccordionTableRows
+                in
                 div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
                     [ Header.init
                         |> Header.view [] [ Text.textLight |> Text.view [] [ text "People" ] ]
@@ -47,7 +51,7 @@ stories =
                         , Text.textLight |> Text.view [] [ text "Occupation" ]
                         , Text.textLight |> Text.view [] [ text "Age" ]
                         ]
-                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
+                    , Row.init (isOpen 0) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Johnny" ]
                             , Text.textLight |> Text.view [] [ text "Carpenter" ]
@@ -55,7 +59,7 @@ stories =
                             ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details about Johnny" ] ]
                         |> Row.view []
-                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 1)
+                    , Row.init (isOpen 1) (Config.AccordionTableRowToggled 1)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Maximilian" ]
                             , Text.textLight |> Text.view [] [ text "Musician" ]
@@ -69,39 +73,45 @@ stories =
         , ( "Selectable rows"
           , \config ->
                 let
-                    allSelected =
-                        Set.size config.customModel.selectedAccordionTableRows == 2
+                    isOpen index =
+                        Set.member index config.customModel.openAccordionTableRows
 
-                    ariaSelected =
-                        Encode.bool allSelected |> Encode.encode 0
+                    isSelected index =
+                        Set.member index config.customModel.selectedAccordionTableRows
+
+                    allSelected =
+                        List.all isSelected [ 0, 1 ]
+
+                    toAriaSelected selected =
+                        attribute "aria-selected" <| (Encode.bool selected |> Encode.encode 0)
                 in
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto auto", gap2 (rem 0) (rem 1), maxWidth (px 800) ] ]
                     [ Header.init
                         |> Header.view
-                            [ css [ displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ], attribute "aria-selected" ariaSelected ]
+                            [ css [ displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ], toAriaSelected allSelected ]
                             [ Text.textLight |> Text.view [] [ text "Selectable rows" ]
                             , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableAllRowsChecked checked)
                                 |> Checkbox.withAppearance Checkbox.Simple
                                 |> Checkbox.withIsChecked allSelected
                                 |> Checkbox.view []
                             ]
-                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
+                    , Row.init (isOpen 0) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Some summary" ]
                             , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableRowChecked 0 checked)
                                 |> Checkbox.withAppearance Checkbox.Simple
-                                |> Checkbox.withIsChecked (Set.member 0 config.customModel.selectedAccordionTableRows)
-                                |> Checkbox.view []
+                                |> Checkbox.withIsChecked (isSelected 0)
+                                |> Checkbox.view [ toAriaSelected (isSelected 0) ]
                             ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
                         |> Row.view []
-                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 1)
+                    , Row.init (isOpen 1) (Config.AccordionTableRowToggled 1)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Some other summary" ]
                             , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableRowChecked 1 checked)
                                 |> Checkbox.withAppearance Checkbox.Simple
-                                |> Checkbox.withIsChecked (Set.member 1 config.customModel.selectedAccordionTableRows)
-                                |> Checkbox.view []
+                                |> Checkbox.withIsChecked (isSelected 1)
+                                |> Checkbox.view [ toAriaSelected (isSelected 1) ]
                             ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "More details" ] ]
                         |> Row.view []

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -1,13 +1,14 @@
 module Stories.AccordionTable exposing (stories)
 
 import Config exposing (Config, Msg)
-import Css exposing (marginBottom, marginLeft, maxWidth, px, rem)
+import Css exposing (color, marginBottom, marginLeft, marginTop, maxWidth, px, rem)
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.AccordionTableHeader as Header
 import Nordea.Components.AccordionTableRow as Row
 import Nordea.Components.Text as Text
 import Nordea.Css exposing (displayGrid, gridColumn, gridTemplateColumns)
+import Nordea.Resources.Colors as Colors
 import Set
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
@@ -23,14 +24,14 @@ stories =
                     [ Header.init
                         |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
-                            [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
+                            [ Text.textLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
-                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary" ] ]
-                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some summary" ] ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
                         |> Row.view []
                     , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
-                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary 2" ] ]
-                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some other summary" ] ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "More details" ] ]
                         |> Row.view []
                     ]
           , {}
@@ -40,18 +41,20 @@ stories =
                 div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
                     [ Header.init
                         |> Header.view
-                            [ css [ marginBottom (rem 1) ] ]
-                            [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
-                    , Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
-                    , Text.textLight |> Text.view [] [ text "Occupation" ]
-                    , Text.textLight |> Text.view [] [ text "Age" ]
+                            []
+                            [ Text.textLight |> Text.view [] [ text "People" ] ]
+                    , div [ css [ color Colors.nordeaGray, marginTop (rem 1), displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ] ]
+                        [ Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
+                        , Text.textLight |> Text.view [] [ text "Occupation" ]
+                        , Text.textLight |> Text.view [] [ text "Age" ]
+                        ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
                         |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Johnny" ]
                             , Text.textLight |> Text.view [] [ text "Carpenter" ]
                             , Text.textLight |> Text.view [] [ text "34" ]
                             ]
-                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details about Johnny" ] ]
                         |> Row.view []
                     , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
                         |> Row.withSummary []
@@ -59,7 +62,7 @@ stories =
                             , Text.textLight |> Text.view [] [ text "Musician" ]
                             , Text.textLight |> Text.view [] [ text "23" ]
                             ]
-                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details about Maximilian" ] ]
                         |> Row.view []
                     ]
           , {}
@@ -71,11 +74,11 @@ stories =
                         |> Header.withSmallSize
                         |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
-                            [ Text.bodyTextSmall |> Text.view [] [ text "Table header" ] ]
+                            [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
                         |> Row.withSmallSize
                         |> Row.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]
-                        |> Row.withDetails [] [ Text.bodyTextSmall |> Text.view [] [ text "Details" ] ]
+                        |> Row.withDetails [] [ Text.textSmallLight |> Text.view [] [ text "Details" ] ]
                         |> Row.view []
                     ]
           , {}

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -3,7 +3,8 @@ module Stories.AccordionTable exposing (stories)
 import Config exposing (Config, Msg)
 import Css exposing (color, display, marginLeft, marginTop, maxWidth, padding, px, rem)
 import Html.Styled exposing (div, text)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes exposing (attribute, css)
+import Json.Encode as Encode
 import Nordea.Components.AccordionTableHeader as Header
 import Nordea.Components.AccordionTableRow as Row
 import Nordea.Components.Checkbox as Checkbox
@@ -71,14 +72,21 @@ stories =
           )
         , ( "Selectable rows"
           , \config ->
+                let
+                    allSelected =
+                        Set.size config.customModel.selectedAccordionTableRows == 2
+
+                    ariaSelected =
+                        Encode.bool allSelected |> Encode.encode 0
+                in
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto auto", gap2 (rem 0) (rem 1), maxWidth (px 800) ] ]
                     [ Header.init
                         |> Header.view
-                            [ css [ displayGrid, gridTemplateColumns "subgrid", color Colors.cloudBlue, padding (rem 1) ] ]
+                            [ css [ displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ], attribute "aria-selected" ariaSelected ]
                             [ Text.textLight |> Text.view [] [ text "Selectable rows" ]
                             , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableAllRowsChecked checked)
                                 |> Checkbox.withAppearance Checkbox.Simple
-                                |> Checkbox.withIsChecked (Set.size config.customModel.selectedAccordionTableRows == 2)
+                                |> Checkbox.withIsChecked allSelected
                                 |> Checkbox.view []
                             ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -4,8 +4,8 @@ import Config exposing (Config, Msg)
 import Css exposing (marginBottom, marginLeft, maxWidth, px, rem)
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
-import Nordea.Components.AccordionTableHeader as AccordionTableHeader
-import Nordea.Components.AccordionTableRow as AccordionTableRow
+import Nordea.Components.AccordionTableHeader as Header
+import Nordea.Components.AccordionTableRow as Row
 import Nordea.Components.Text as Text
 import Nordea.Css exposing (displayGrid, gridColumn, gridTemplateColumns)
 import Set
@@ -20,63 +20,63 @@ stories =
         [ ( "Default"
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 800) ] ]
-                    [ AccordionTableHeader.init
-                        |> AccordionTableHeader.view
+                    [ Header.init
+                        |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
                             [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
-                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
-                        |> AccordionTableRow.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary" ] ]
-                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
-                        |> AccordionTableRow.view []
-                    , AccordionTableRow.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
-                        |> AccordionTableRow.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary 2" ] ]
-                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
-                        |> AccordionTableRow.view []
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary" ] ]
+                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> Row.view []
+                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                        |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary 2" ] ]
+                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> Row.view []
                     ]
           , {}
           )
         , ( "Multiple columns"
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
-                    [ AccordionTableHeader.init
-                        |> AccordionTableHeader.view
+                    [ Header.init
+                        |> Header.view
                             [ css [ marginBottom (rem 1) ] ]
                             [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
                     , Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
                     , Text.textLight |> Text.view [] [ text "Occupation" ]
                     , Text.textLight |> Text.view [] [ text "Age" ]
-                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
-                        |> AccordionTableRow.withSummary []
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Johnny" ]
                             , Text.textLight |> Text.view [] [ text "Carpenter" ]
                             , Text.textLight |> Text.view [] [ text "34" ]
                             ]
-                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
-                        |> AccordionTableRow.view []
-                    , AccordionTableRow.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
-                        |> AccordionTableRow.withSummary []
+                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> Row.view []
+                    , Row.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                        |> Row.withSummary []
                             [ Text.textLight |> Text.view [] [ text "Maximilian" ]
                             , Text.textLight |> Text.view [] [ text "Musician" ]
                             , Text.textLight |> Text.view [] [ text "23" ]
                             ]
-                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
-                        |> AccordionTableRow.view []
+                        |> Row.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> Row.view []
                     ]
           , {}
           )
         , ( "Small"
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 600) ] ]
-                    [ AccordionTableHeader.init
-                        |> AccordionTableHeader.withSmallSize
-                        |> AccordionTableHeader.view
+                    [ Header.init
+                        |> Header.withSmallSize
+                        |> Header.view
                             [ css [ gridColumn "1/-1" ] ]
                             [ Text.bodyTextSmall |> Text.view [] [ text "Table header" ] ]
-                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
-                        |> AccordionTableRow.withSmallSize
-                        |> AccordionTableRow.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]
-                        |> AccordionTableRow.withDetails [] [ Text.bodyTextSmall |> Text.view [] [ text "Details" ] ]
-                        |> AccordionTableRow.view []
+                    , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> Row.withSmallSize
+                        |> Row.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]
+                        |> Row.withDetails [] [ Text.bodyTextSmall |> Text.view [] [ text "Details" ] ]
+                        |> Row.view []
                     ]
           , {}
           )

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -1,18 +1,16 @@
 module Stories.AccordionTable exposing (stories)
 
 import Config exposing (Config, Msg)
-import Css exposing (color, marginBottom, marginLeft, maxWidth, px, rem)
+import Css exposing (marginBottom, marginLeft, maxWidth, px, rem)
 import Html.Styled exposing (div, text)
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.AccordionTableHeader as AccordionTableHeader
 import Nordea.Components.AccordionTableRow as AccordionTableRow
 import Nordea.Components.Text as Text
 import Nordea.Css exposing (displayGrid, gridColumn, gridTemplateColumns)
-import Nordea.Resources.Colors as Colors
-import Set exposing (Set)
+import Set
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
-
 
 
 stories : UI Config Msg {}

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -25,7 +25,7 @@ stories =
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 800) ] ]
                     [ Header.init
-                        |> Header.view [] [ Text.textLight |> Text.view [] [ text "Table header" ] ]
+                        |> Header.view [] [] [ Text.textLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some summary" ] ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
@@ -45,7 +45,7 @@ stories =
                 in
                 div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
                     [ Header.init
-                        |> Header.view [] [ Text.textLight |> Text.view [] [ text "People" ] ]
+                        |> Header.view [] [] [ Text.textLight |> Text.view [] [ text "People" ] ]
                     , div [ css [ color Colors.nordeaGray, marginTop (rem 1), displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ] ]
                         [ Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
                         , Text.textLight |> Text.view [] [ text "Occupation" ]
@@ -88,7 +88,8 @@ stories =
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto auto", gap2 (rem 0) (rem 1), maxWidth (px 800) ] ]
                     [ Header.init
                         |> Header.view
-                            [ css [ displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ], toAriaSelected allSelected ]
+                            [ displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ]
+                            [ toAriaSelected allSelected ]
                             [ Text.textLight |> Text.view [] [ text "Selectable rows" ]
                             , Checkbox.init "selectable-rows" nothing (\checked -> Config.AccordionTableAllRowsChecked checked)
                                 |> Checkbox.withAppearance Checkbox.Simple
@@ -123,7 +124,7 @@ stories =
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 600) ] ]
                     [ Header.init
                         |> Header.withSmallSize
-                        |> Header.view [] [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
+                        |> Header.view [] [] [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSmallSize
                         |> Row.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -1,0 +1,85 @@
+module Stories.AccordionTable exposing (stories)
+
+import Config exposing (Config, Msg)
+import Css exposing (color, marginBottom, marginLeft, maxWidth, px, rem)
+import Html.Styled exposing (div, text)
+import Html.Styled.Attributes exposing (css)
+import Nordea.Components.AccordionTableHeader as AccordionTableHeader
+import Nordea.Components.AccordionTableRow as AccordionTableRow
+import Nordea.Components.Text as Text
+import Nordea.Css exposing (displayGrid, gridColumn, gridTemplateColumns)
+import Nordea.Resources.Colors as Colors
+import Set exposing (Set)
+import UIExplorer exposing (UI)
+import UIExplorer.Styled exposing (styledStoriesOf)
+
+
+
+stories : UI Config Msg {}
+stories =
+    styledStoriesOf
+        "AccordionTable"
+        [ ( "Default"
+          , \config ->
+                div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 800) ] ]
+                    [ AccordionTableHeader.init
+                        |> AccordionTableHeader.view
+                            [ css [ gridColumn "1/-1" ] ]
+                            [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
+                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> AccordionTableRow.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary" ] ]
+                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> AccordionTableRow.view []
+                    , AccordionTableRow.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                        |> AccordionTableRow.withSummary [] [ Text.textLight |> Text.view [] [ text "Summary 2" ] ]
+                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> AccordionTableRow.view []
+                    ]
+          , {}
+          )
+        , ( "Multiple columns"
+          , \config ->
+                div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
+                    [ AccordionTableHeader.init
+                        |> AccordionTableHeader.view
+                            [ css [ marginBottom (rem 1) ] ]
+                            [ Text.bodyTextLight |> Text.view [] [ text "Table header" ] ]
+                    , Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
+                    , Text.textLight |> Text.view [] [ text "Occupation" ]
+                    , Text.textLight |> Text.view [] [ text "Age" ]
+                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> AccordionTableRow.withSummary []
+                            [ Text.textLight |> Text.view [] [ text "Johnny" ]
+                            , Text.textLight |> Text.view [] [ text "Carpenter" ]
+                            , Text.textLight |> Text.view [] [ text "34" ]
+                            ]
+                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details" ] ]
+                        |> AccordionTableRow.view []
+                    , AccordionTableRow.init (Set.member 1 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 1)
+                        |> AccordionTableRow.withSummary []
+                            [ Text.textLight |> Text.view [] [ text "Maximilian" ]
+                            , Text.textLight |> Text.view [] [ text "Musician" ]
+                            , Text.textLight |> Text.view [] [ text "23" ]
+                            ]
+                        |> AccordionTableRow.withDetails [] [ Text.bodyTextLight |> Text.view [] [ text "Details 2" ] ]
+                        |> AccordionTableRow.view []
+                    ]
+          , {}
+          )
+        , ( "Small"
+          , \config ->
+                div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 600) ] ]
+                    [ AccordionTableHeader.init
+                        |> AccordionTableHeader.withSmallSize
+                        |> AccordionTableHeader.view
+                            [ css [ gridColumn "1/-1" ] ]
+                            [ Text.bodyTextSmall |> Text.view [] [ text "Table header" ] ]
+                    , AccordionTableRow.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableMsg 0)
+                        |> AccordionTableRow.withSmallSize
+                        |> AccordionTableRow.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]
+                        |> AccordionTableRow.withDetails [] [ Text.bodyTextSmall |> Text.view [] [ text "Details" ] ]
+                        |> AccordionTableRow.view []
+                    ]
+          , {}
+          )
+        ]

--- a/explorer/src/Stories/AccordionTable.elm
+++ b/explorer/src/Stories/AccordionTable.elm
@@ -25,9 +25,7 @@ stories =
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 800) ] ]
                     [ Header.init
-                        |> Header.view
-                            [ css [ gridColumn "1/-1" ] ]
-                            [ Text.textLight |> Text.view [] [ text "Table header" ] ]
+                        |> Header.view [] [ Text.textLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSummary [] [ Text.textLight |> Text.view [] [ text "Some summary" ] ]
                         |> Row.withDetails [] [ Text.textLight |> Text.view [] [ text "Details" ] ]
@@ -43,9 +41,7 @@ stories =
           , \config ->
                 div [ css [ displayGrid, gridTemplateColumns "repeat(3, 1fr) auto", maxWidth (px 800) ] ]
                     [ Header.init
-                        |> Header.view
-                            []
-                            [ Text.textLight |> Text.view [] [ text "People" ] ]
+                        |> Header.view [] [ Text.textLight |> Text.view [] [ text "People" ] ]
                     , div [ css [ color Colors.nordeaGray, marginTop (rem 1), displayGrid, gridTemplateColumns "subgrid", gridColumn "1/-1" ] ]
                         [ Text.textLight |> Text.view [ css [ marginLeft (rem 1) ] ] [ text "Name" ]
                         , Text.textLight |> Text.view [] [ text "Occupation" ]
@@ -117,9 +113,7 @@ stories =
                 div [ css [ displayGrid, gridTemplateColumns "1fr auto", maxWidth (px 600) ] ]
                     [ Header.init
                         |> Header.withSmallSize
-                        |> Header.view
-                            [ css [ gridColumn "1/-1" ] ]
-                            [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
+                        |> Header.view [] [ Text.textSmallLight |> Text.view [] [ text "Table header" ] ]
                     , Row.init (Set.member 0 config.customModel.openAccordionTableRows) (Config.AccordionTableRowToggled 0)
                         |> Row.withSmallSize
                         |> Row.withSummary [] [ Text.textSmallLight |> Text.view [] [ text "Summary" ] ]

--- a/src/Nordea/Components/AccordionTableHeader.elm
+++ b/src/Nordea/Components/AccordionTableHeader.elm
@@ -20,8 +20,8 @@ init =
     }
 
 
-view : List (Html.Attribute msg) -> List (Html msg) -> Config -> Html msg
-view attrs content config =
+view : List Css.Style -> List (Html.Attribute msg) -> List (Html msg) -> Config -> Html msg
+view styles attrs content config =
     let
         ( horizontalPadding, verticalPadding ) =
             if config.small then
@@ -30,19 +30,20 @@ view attrs content config =
             else
                 ( 1, 0.75 )
 
-        combinedAttrs =
+        combinedStyles =
             css
-                [ gridColumn "1 / -1"
-                , color Colors.black
-                , padding2 (rem verticalPadding) (rem horizontalPadding)
-                , backgroundColor Colors.cloudBlue
-                , borderRadius (rem 0.5)
-                ]
-                :: attrs
+                ([ gridColumn "1 / -1"
+                 , color Colors.black
+                 , padding2 (rem verticalPadding) (rem horizontalPadding)
+                 , backgroundColor Colors.cloudBlue
+                 , borderRadius (rem 0.5)
+                 ]
+                    ++ styles
+                )
     in
     Text.textTinyHeavy
         |> Text.withHtmlTag h3
-        |> Text.view combinedAttrs content
+        |> Text.view (combinedStyles :: attrs) content
 
 
 withSmallSize : Config -> Config

--- a/src/Nordea/Components/AccordionTableHeader.elm
+++ b/src/Nordea/Components/AccordionTableHeader.elm
@@ -1,11 +1,11 @@
 module Nordea.Components.AccordionTableHeader exposing (init, view, withSmallSize)
 
-import Css exposing (borderRadius, padding2, rem)
+import Css exposing (backgroundColor, borderRadius, padding2, rem)
 import Html.Styled as Html exposing (Html, h3)
 import Nordea.Components.Text as Text
 import Nordea.Css exposing (gridColumn)
 import Nordea.Resources.Colors as Colors
-import Nordea.Themes exposing (backgroundColor, color)
+import Nordea.Themes exposing (color)
 import Svg.Styled.Attributes exposing (css)
 
 
@@ -29,11 +29,9 @@ view attrs content config =
 
             else
                 ( 1, 0.75 )
-    in
-    Text.textTinyHeavy
-        |> Text.withHtmlTag h3
-        |> Text.view
-            (css
+
+        combinedAttrs =
+            css
                 [ gridColumn "1 / -1"
                 , color Colors.black
                 , padding2 (rem verticalPadding) (rem horizontalPadding)
@@ -41,8 +39,10 @@ view attrs content config =
                 , borderRadius (rem 0.5)
                 ]
                 :: attrs
-            )
-            content
+    in
+    Text.textTinyHeavy
+        |> Text.withHtmlTag h3
+        |> Text.view combinedAttrs content
 
 
 withSmallSize : Config -> Config

--- a/src/Nordea/Components/AccordionTableHeader.elm
+++ b/src/Nordea/Components/AccordionTableHeader.elm
@@ -1,0 +1,50 @@
+module Nordea.Components.AccordionTableHeader exposing (init, view, withSmallSize)
+
+import Css exposing (borderRadius, padding2, rem)
+import Html.Styled as Html exposing (Html, h3)
+import Nordea.Components.Text as Text
+import Nordea.Css exposing (gridColumn)
+import Nordea.Resources.Colors as Colors
+import Nordea.Themes exposing (backgroundColor, color)
+import Svg.Styled.Attributes exposing (css)
+
+
+type alias Config =
+    { small : Bool
+    }
+
+
+init : Config
+init =
+    { small = False
+    }
+
+
+view : List (Html.Attribute msg) -> List (Html msg) -> Config -> Html msg
+view attrs content config =
+    let
+        ( horizontalPadding, verticalPadding ) =
+            if config.small then
+                ( 0.75, 0.5 )
+
+            else
+                ( 1, 0.75 )
+    in
+    Text.textTinyHeavy
+        |> Text.withHtmlTag h3
+        |> Text.view
+            (css
+                [ gridColumn "1 / -1"
+                , color Colors.black
+                , padding2 (rem verticalPadding) (rem horizontalPadding)
+                , backgroundColor Colors.cloudBlue
+                , borderRadius (rem 0.5)
+                ]
+                :: attrs
+            )
+            content
+
+
+withSmallSize : Config -> Config
+withSmallSize config =
+    { config | small = True }

--- a/src/Nordea/Components/AccordionTableRow.elm
+++ b/src/Nordea/Components/AccordionTableRow.elm
@@ -1,6 +1,6 @@
 module Nordea.Components.AccordionTableRow exposing (init, view, withChevron, withDetails, withSmallSize, withSummary)
 
-import Css exposing (alignItems, backgroundColor, border3, borderRadius, borderRadius4, center, color, cursor, display, hover, important, marginTop, padding, padding2, pointer, rem, solid, unset, width)
+import Css exposing (alignItems, backgroundColor, border3, borderRadius, borderRadius4, center, color, cursor, display, hover, important, lineHeight, marginTop, padding, padding2, pointer, rem, solid, unset, width)
 import Css.Global exposing (children, typeSelector)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (attribute, css)
@@ -180,6 +180,7 @@ viewChevron isOpen =
     Html.div
         [ css
             [ width (rem 1)
+            , lineHeight (rem 1)
             , children [ typeSelector "*" [ display unset |> important ] ]
             ]
         ]

--- a/src/Nordea/Components/AccordionTableRow.elm
+++ b/src/Nordea/Components/AccordionTableRow.elm
@@ -1,0 +1,176 @@
+module Nordea.Components.AccordionTableRow exposing (init, view, withChevron, withDetails, withSmallSize, withSummary)
+
+import Css exposing (alignItems, backgroundColor, border3, borderRadius, borderRadius4, center, color, cursor, display, hover, important, marginTop, padding, padding2, pointer, rem, solid, unset, width)
+import Css.Global exposing (children, typeSelector)
+import Html.Styled as Html exposing (Html)
+import Html.Styled.Attributes exposing (attribute, css)
+import Html.Styled.Events as Events
+import Json.Decode as Decode
+import Nordea.Css exposing (displayContents, displayGrid, gridColumn, gridTemplateColumns)
+import Nordea.Html exposing (nothing)
+import Nordea.Html.Attributes exposing (boolProperty)
+import Nordea.Resources.Colors as Colors
+import Nordea.Resources.Icons as Icons
+import Nordea.Themes as Themes
+
+
+type alias Config msg =
+    { summary : Html msg
+    , details : Html msg
+    , isOpen : Bool
+    , onToggle : Bool -> msg
+    , size : Size
+    , showChevron : Bool
+    }
+
+
+type Size
+    = Standard
+    | Small
+
+
+init : Bool -> (Bool -> msg) -> Config msg
+init isOpen onToggle =
+    { summary = nothing
+    , details = nothing
+    , isOpen = isOpen
+    , onToggle = onToggle
+    , size = Standard
+    , showChevron = True
+    }
+
+
+withSmallSize : Config msg -> Config msg
+withSmallSize config =
+    { config
+        | size = Small
+    }
+
+
+withChevron : Bool -> Config msg -> Config msg
+withChevron show config =
+    { config
+        | showChevron = show
+    }
+
+
+withSummary : List (Html.Attribute msg) -> List (Html msg) -> Config msg -> Config msg
+withSummary attrs content config =
+    let
+        openCss =
+            if config.isOpen then
+                [ css
+                    [ important (backgroundColor Colors.deepBlue)
+                    , important (color Colors.white)
+                    , important (borderRadius4 (rem 0.5) (rem 0.5) (rem 0) (rem 0))
+                    ]
+                ]
+
+            else
+                []
+
+        ( horizontalPadding, verticalPadding ) =
+            case config.size of
+                Small ->
+                    ( 0.75, 0.5 )
+
+                Standard ->
+                    ( 1, 0.75 )
+    in
+    { config
+        | summary =
+            Html.summary
+                ([ css
+                    [ displayGrid
+                    , gridColumn "1/-1"
+                    , gridTemplateColumns "subgrid"
+                    , alignItems center
+                    , cursor pointer
+                    , marginTop (rem 1)
+                    , padding2 (rem verticalPadding) (rem horizontalPadding)
+                    , borderRadius (rem 0.5)
+                    , Themes.color Colors.darkestGray
+                    , backgroundColor Colors.grayWarm
+                    , hover [ cursor pointer, backgroundColor Colors.deepBlue, color Colors.white ]
+                    ]
+                 , attribute "role" "row"
+                 ]
+                    ++ openCss
+                    ++ attrs
+                )
+                (content
+                    ++ [ if config.showChevron then
+                            viewChevron config.isOpen
+
+                         else
+                            nothing
+                       ]
+                )
+    }
+
+
+withDetails : List (Html.Attribute msg) -> List (Html msg) -> Config msg -> Config msg
+withDetails attrs content config =
+    { config
+        | details =
+            Html.div
+                (css
+                    [ padding (rem 1.5)
+                    , border3 (rem 0.1875) solid Colors.deepBlue
+                    , borderRadius4 (rem 0) (rem 0) (rem 0.5) (rem 0.5)
+                    , gridColumn "1/-1"
+                    ]
+                    :: attrs
+                )
+                content
+    }
+
+
+view : List (Html.Attribute msg) -> Config msg -> Html msg
+view attrs config =
+    Html.details
+        ([ css [ displayContents ]
+         , boolProperty "open" config.isOpen
+         , Events.on "toggle" (Decode.map config.onToggle decodeNewState)
+         ]
+            ++ attrs
+        )
+        [ config.summary
+        , config.details
+        ]
+
+
+viewChevron : Bool -> Html msg
+viewChevron isOpen =
+    let
+        icon =
+            if isOpen then
+                Icons.chevronUp []
+
+            else
+                Icons.chevronDown []
+    in
+    Html.div
+        [ css
+            [ width (rem 1)
+            , children [ typeSelector "*" [ display unset |> important ] ]
+            ]
+        ]
+        [ icon ]
+
+
+decodeNewState : Decode.Decoder Bool
+decodeNewState =
+    Decode.field "newState" Decode.string
+        |> Decode.andThen
+            (\state ->
+                case state of
+                    "open" ->
+                        Decode.succeed True
+
+                    "closed" ->
+                        Decode.succeed False
+
+                    _ ->
+                        Decode.fail "Invalid state"
+            )


### PR DESCRIPTION
I've added two new components from FinansFront:

- AccordionTableHeader
- AccordionTableRow

When these are used inside a CSS Grid, you can compose this sort of «AccordionTable». Note that the column headers are not part of the library.

<img width="826" alt="image" src="https://github.com/user-attachments/assets/b7c1d3f7-3983-4c64-89a5-f17c33194dec">

Here's the smaller variant for FinansFront:

<img width="625" alt="image" src="https://github.com/user-attachments/assets/f1d1ed96-5bf6-4b99-a03b-217ef5758d6c">

This layout style is used all over the place in new sketches, including the new Supplier Invoice Page, Change of Party applications and the new ESign page in FinansFront.

## Implementation

The AccordionTable is a mix of two features; the CSS Grid specification and the details/summary HTML elements.

The details and summary are native HTML elements that make the accordions expand and collapse when clicked. They are accessible and works without Javascript.

Each row in the table are made out of these elements. So how do we align the rows in the table? That's where the CSS Grid comes into play. You specify the number of columns and their width in the top element, and all rows are aligned automatically. The CSS Subgrid spec is used to «skip» the `summary` elements so that the columns inside are aligned to the Grid, not the summary element itself.