### PR TITLE
Add smaller status components

### DIFF
--- a/explorer/src/Stories/Status.elm
+++ b/explorer/src/Stories/Status.elm
@@ -34,4 +34,12 @@ stories =
           , \_ -> Status.partiallyFilled "Control prerequisites" Color.yellowStatus 60.0 []
           , {}
           )
+        , ( "Small"
+          , \_ -> Status.small Status.CloudBlue "Status" []
+          , {}
+          )
+        , ( "Small Mixed"
+          , \_ -> Status.smallPartiallyFilled "Control prerequisites" Color.yellowStatus 60.0 []
+          , {}
+          )
         ]

--- a/src/Nordea/Components/Status.elm
+++ b/src/Nordea/Components/Status.elm
@@ -13,11 +13,9 @@ import Css
         , ellipsis
         , height
         , hidden
-        , important
         , inlineBlock
         , left
         , overflow
-        , padding
         , padding2
         , pct
         , position
@@ -45,18 +43,18 @@ type StatusColor
 view : String -> StatusColor -> Bool -> List (Attribute msg) -> Html msg
 view text statusColor isSmall attrs =
     let
-        padding =
+        ( paddingStyle, borderRadiusStyle ) =
             if isSmall then
-                padding2 (rem 0.25) (rem 0.5)
+                ( padding2 (rem 0.25) (rem 0.5), borderRadius (rem 0.5) )
 
             else
-                padding2 (rem 0.5) (rem 0.75)
+                ( padding2 (rem 0.5) (rem 0.75), borderRadius (rem 0.75) )
 
         attrs_ bgColor =
             css
                 [ display inlineBlock
-                , borderRadius (rem 0.75)
-                , padding
+                , borderRadiusStyle
+                , paddingStyle
                 , backgroundColor bgColor
                 , textOverflow ellipsis
                 , overflow hidden

--- a/src/Nordea/Components/Status.elm
+++ b/src/Nordea/Components/Status.elm
@@ -1,4 +1,4 @@
-module Nordea.Components.Status exposing (blue, gray, green, partiallyFilled, red, yellow)
+module Nordea.Components.Status exposing (StatusColor(..), blue, gray, green, partiallyFilled, red, small, smallPartiallyFilled, yellow)
 
 import Css
     exposing
@@ -13,10 +13,12 @@ import Css
         , ellipsis
         , height
         , hidden
+        , important
         , inlineBlock
         , left
         , overflow
         , padding
+        , padding2
         , pct
         , position
         , relative
@@ -40,19 +42,21 @@ type StatusColor
     | TwoColors Color Color Float
 
 
-view : String -> StatusColor -> List (Attribute msg) -> Html msg
-view text statusColor attrs =
+view : String -> StatusColor -> List Css.Style -> List (Attribute msg) -> Html msg
+view text statusColor styles attrs =
     let
         attrs_ bgColor =
             css
-                [ display inlineBlock
-                , borderRadius (rem 0.75)
-                , padding (rem 0.5)
-                , backgroundColor bgColor
-                , textOverflow ellipsis
-                , overflow hidden
-                , position relative
-                ]
+                ([ display inlineBlock
+                 , borderRadius (rem 0.75)
+                 , padding2 (rem 0.5) (rem 0.75)
+                 , backgroundColor bgColor
+                 , textOverflow ellipsis
+                 , overflow hidden
+                 , position relative
+                 ]
+                    ++ styles
+                )
                 :: attrs
 
         twoColorAttrs_ colorDone colorUndone pctDone =
@@ -114,29 +118,42 @@ view text statusColor attrs =
 
 green : String -> List (Attribute msg) -> Html msg
 green text =
-    view text Green
+    view text Green []
 
 
 yellow : String -> List (Attribute msg) -> Html msg
 yellow text =
-    view text Yellow
+    view text Yellow []
 
 
 red : String -> List (Attribute msg) -> Html msg
 red text =
-    view text Red
+    view text Red []
 
 
 blue : String -> List (Attribute msg) -> Html msg
 blue text =
-    view text CloudBlue
+    view text CloudBlue []
 
 
 gray : String -> List (Attribute msg) -> Html msg
 gray text =
-    view text LightGray
+    view text LightGray []
+
+
+small : StatusColor -> String -> List (Attribute msg) -> Html msg
+small color text attrs =
+    view text color [ padding2 (rem 0.25) (rem 0.5) ] attrs
 
 
 partiallyFilled : String -> Color -> Float -> List (Attribute msg) -> Html msg
 partiallyFilled text colorDone pctDone =
-    view text (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone)
+    view text (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone) []
+
+
+smallPartiallyFilled : String -> Color -> Float -> List (Attribute msg) -> Html msg
+smallPartiallyFilled text colorDone pctDone attrs =
+    view text
+        (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone)
+        [ padding2 (rem 0.25) (rem 0.5) ]
+        attrs

--- a/src/Nordea/Components/Status.elm
+++ b/src/Nordea/Components/Status.elm
@@ -42,21 +42,26 @@ type StatusColor
     | TwoColors Color Color Float
 
 
-view : String -> StatusColor -> List Css.Style -> List (Attribute msg) -> Html msg
-view text statusColor styles attrs =
+view : String -> StatusColor -> Bool -> List (Attribute msg) -> Html msg
+view text statusColor isSmall attrs =
     let
+        padding =
+            if isSmall then
+                padding2 (rem 0.25) (rem 0.5)
+
+            else
+                padding2 (rem 0.5) (rem 0.75)
+
         attrs_ bgColor =
             css
-                ([ display inlineBlock
-                 , borderRadius (rem 0.75)
-                 , padding2 (rem 0.5) (rem 0.75)
-                 , backgroundColor bgColor
-                 , textOverflow ellipsis
-                 , overflow hidden
-                 , position relative
-                 ]
-                    ++ styles
-                )
+                [ display inlineBlock
+                , borderRadius (rem 0.75)
+                , padding
+                , backgroundColor bgColor
+                , textOverflow ellipsis
+                , overflow hidden
+                , position relative
+                ]
                 :: attrs
 
         twoColorAttrs_ colorDone colorUndone pctDone =
@@ -118,42 +123,39 @@ view text statusColor styles attrs =
 
 green : String -> List (Attribute msg) -> Html msg
 green text =
-    view text Green []
+    view text Green False
 
 
 yellow : String -> List (Attribute msg) -> Html msg
 yellow text =
-    view text Yellow []
+    view text Yellow False
 
 
 red : String -> List (Attribute msg) -> Html msg
 red text =
-    view text Red []
+    view text Red False
 
 
 blue : String -> List (Attribute msg) -> Html msg
 blue text =
-    view text CloudBlue []
+    view text CloudBlue False
 
 
 gray : String -> List (Attribute msg) -> Html msg
 gray text =
-    view text LightGray []
+    view text LightGray False
 
 
 small : StatusColor -> String -> List (Attribute msg) -> Html msg
 small color text attrs =
-    view text color [ padding2 (rem 0.25) (rem 0.5) ] attrs
+    view text color True attrs
 
 
 partiallyFilled : String -> Color -> Float -> List (Attribute msg) -> Html msg
 partiallyFilled text colorDone pctDone =
-    view text (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone) []
+    view text (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone) False
 
 
 smallPartiallyFilled : String -> Color -> Float -> List (Attribute msg) -> Html msg
 smallPartiallyFilled text colorDone pctDone attrs =
-    view text
-        (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone)
-        [ padding2 (rem 0.25) (rem 0.5) ]
-        attrs
+    view text (TwoColors colorDone (colorDone |> Color.withAlpha 0.4) pctDone) True attrs


### PR DESCRIPTION
Add a small variant of the Status component for FinansFront. Also, add some extra _horizontal_ padding on the larger variant (from `0.5` to `0.75rem`), as discussed with Line.

<img width="577" alt="image" src="https://github.com/user-attachments/assets/abad51a6-896a-4723-a981-83167893a54f">

<img width="585" alt="image" src="https://github.com/user-attachments/assets/2273dd17-1881-4e14-9a2d-aaca8b863f04">

<img width="583" alt="image" src="https://github.com/user-attachments/assets/93eeeadb-1486-4a96-bee9-bf86f8a1f4cb">
