### PR TITLE
Handle text overflow for chat 

### DIFF
--- a/explorer/src/Stories/Chat.elm
+++ b/explorer/src/Stories/Chat.elm
@@ -61,7 +61,7 @@ stories =
                                             , isUserMessage = False
                                             }
                                         , Chat.chatHistoryView []
-                                            { sentFrom = "PartnerHub"
+                                            { sentFrom = "Nordea Finance Equipment AS - Long company name"
                                             , sentAt = "30.05.2024, kl. 13:54"
                                             , sender = Just "Thomas Olsen"
                                             , message = "Har lagt ved resultatrapport og balanserepport pr. 31.11.2023. Vi har ikke fått tilbake rapportene for des. 2023 fra regnskap firma."

--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -8,19 +8,24 @@ import Css
         , borderRadius4
         , color
         , columnReverse
+        , ellipsis
         , flexDirection
         , flexEnd
+        , hidden
         , justifyContent
         , marginBottom
         , marginLeft
         , marginRight
         , maxHeight
+        , noWrap
         , overflow
         , padding
         , paddingRight
         , rem
         , solid
         , spaceBetween
+        , textOverflow
+        , whiteSpace
         , width
         )
 import Html.Styled as Html exposing (Attribute, Html)
@@ -167,14 +172,14 @@ chatHistoryView attrs { sentFrom, sentAt, sender, message, isUserMessage } =
                 , Themes.backgroundColor Colors.nordeaBlue
                 ]
 
-        messageLabel text =
+        messageLabel attr text =
             Text.textTinyLight
-                |> Text.view [ css [ color Colors.darkGray ] ] [ Html.text text ]
+                |> Text.view (css [ color Colors.darkGray, whiteSpace noWrap ] :: attr) [ Html.text text ]
     in
     Html.column (css [ gap (rem 0.25) ] :: attrs)
         [ Html.row [ css [ justifyContent spaceBetween ] ]
-            [ messageLabel sentFrom
-            , messageLabel sentAt
+            [ messageLabel [ css [ marginRight (rem 0.25), textOverflow ellipsis, overflow hidden ] ] sentFrom
+            , messageLabel [] sentAt
             ]
         , sender
             |> Maybe.map


### PR DESCRIPTION
Handle text overflow when the chat `sentFrom`  value is too long.

![image](https://github.com/user-attachments/assets/f508f802-0228-4fec-bb9d-32beda66747e)
