### PR TITLE
Change max height of chat history

### DIFF
--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -136,7 +136,7 @@ view optionals attrs history content (Chat config) =
             in
             Html.column
                 [ css
-                    [ maxHeight (rem 14)
+                    [ maxHeight (rem 15)
                     , overflow auto
                     , Css.property "scrollbar-width" "thin"
                     , paddingRight (rem 0.3125)

--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -136,8 +136,9 @@ view optionals attrs history content (Chat config) =
             in
             Html.column
                 [ css
-                    [ maxHeight (rem 32)
+                    [ maxHeight (rem 14)
                     , overflow auto
+                    , Css.property "scrollbar-width" "thin"
                     , paddingRight (rem 0.3125)
                     , flexDirection columnReverse |> Css.important
                     ]


### PR DESCRIPTION
Chat history max height is too long so reduced it. Also made the scroll bar width to be thin. 