### PR TITLE
Workaround for Chrome bug in details element

### DIFF
--- a/src/Nordea/Components/AccordionTableRow.elm
+++ b/src/Nordea/Components/AccordionTableRow.elm
@@ -1,6 +1,6 @@
 module Nordea.Components.AccordionTableRow exposing (init, view, withChevron, withDetails, withSmallSize, withSummary)
 
-import Css exposing (alignItems, backgroundColor, border3, borderRadius, borderRadius4, center, color, cursor, display, hover, important, lineHeight, marginTop, padding, padding2, pointer, rem, solid, unset, width)
+import Css exposing (alignItems, backgroundColor, border3, borderRadius, borderRadius4, center, color, cursor, display, hover, important, lineHeight, marginTop, padding, padding2, pointer, pseudoClass, pseudoElement, rem, solid, unset, width)
 import Css.Global exposing (children, typeSelector)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (attribute, css)
@@ -89,8 +89,17 @@ withDetails attrs content config =
 
 view : List (Html.Attribute msg) -> Config msg -> Html msg
 view attrs config =
+    let
+        displayContentsWithFix =
+            [ displayContents
+
+            -- Fix for bug in Chrome (https://issues.chromium.org/issues/40069963)
+            , pseudoClass "not([open])::details-content" [ Css.property "display" "none" ]
+            , pseudoElement "details-content" [ displayContents ]
+            ]
+    in
     Html.details
-        ([ css [ displayContents ]
+        ([ css displayContentsWithFix
          , boolProperty "open" config.isOpen
          , Events.on "toggle" (Decode.map config.onToggle decodeNewState)
          ]


### PR DESCRIPTION
This is a workaround for a bug in Chrome that messes up the Grid layout when using the HTML details element together with the `display: contents` rule. The bug is currently apparent on the Supplier Invoice and Change of Party pages in FinansFront.

Fixed as described on the Chrome bug tracking site: https://issues.chromium.org/issues/40069963

Before:

![image](https://github.com/user-attachments/assets/fdc4c18b-98b9-46b3-b278-9bcdb00d5f48)

After:

![image](https://github.com/user-attachments/assets/1a020744-c382-4df6-be07-631ac42b2e6a)
