### PR TITLE
Avoid jerking the UI when showing error message

### DIFF
--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -49,6 +49,7 @@ type alias Config =
     , showCoachMarkStep : Maybe Int
     , activeRadioButton : String
     , textInputContent : String
+    , labelInputContent : String
     , sortableTable : Stories.SortableTableSharedTypes.Model
     , selectedSearchComponent : Maybe (Item FinancingVariant)
     , selectedSearchComponentOrgInfo : Maybe OrganizationInfo
@@ -88,6 +89,7 @@ type Msg
     | UpdateCoachmarkStep (Maybe Int)
     | UpdateActiveRadioButton String
     | TextInputContentChange String
+    | LabelInputContentChange String
     | OnClickCollapsible
     | SortableTableMsg Stories.SortableTableSharedTypes.Msg
     | SnackbarMsg
@@ -135,6 +137,7 @@ init =
     , showCoachMarkStep = Nothing
     , activeRadioButton = "second"
     , textInputContent = "Initialized"
+    , labelInputContent = "Text"
     , sortableTable = Stories.SortableTableSharedTypes.initModel
     , paginationCurrentPage = 1
     , datePicker = DatePicker.init (Date.fromCalendarDate 2024 May 1) "" DateSelected UpdateDatePickerInternalState
@@ -258,6 +261,9 @@ update msg config =
 
         TextInputContentChange string ->
             { config | textInputContent = string }
+
+        LabelInputContentChange string ->
+            { config | labelInputContent = string }
 
         OnClickCollapsible ->
             config

--- a/explorer/src/Stories/Label.elm
+++ b/explorer/src/Stories/Label.elm
@@ -1,9 +1,10 @@
 module Stories.Label exposing (stories)
 
-import Config exposing (Msg(..))
+import Config exposing (Config, Msg(..))
 import Css exposing (column, displayFlex, flexDirection, marginRight, maxWidth, rem)
 import Html.Styled as Html exposing (text)
 import Html.Styled.Attributes exposing (css)
+import Maybe.Extra as Maybe
 import Nordea.Components.Checkbox as Checkbox
 import Nordea.Components.Dropdown as Dropdown
 import Nordea.Components.Label as Label
@@ -14,56 +15,67 @@ import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
 
-stories : UI a Msg {}
+stories : UI Config Msg {}
 stories =
     styledStoriesOf
         "Label"
         [ ( "With text input"
-          , \_ ->
+          , \model ->
                 Html.div [ css [ displayFlex, flexDirection column, maxWidth (rem 20), gap (rem 2) ] ]
                     [ Label.init "Customer name" Label.InputLabel
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with error)" Label.InputLabel
-                        |> Label.withErrorMessage (Just "The input is invalid")
+                        |> Label.withErrorMessage
+                            (Just model.customModel.labelInputContent
+                                |> Maybe.filter (\s -> String.length s > 0)
+                                |> Maybe.map (\_ -> "The input is invalid")
+                            )
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.withError True
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with hint)" Label.InputLabel
                         |> Label.withHintText (Just "This is some extra hint")
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with error and hint)" Label.InputLabel
                         |> Label.withHintText (Just "This is some extra hint")
                         |> Label.withErrorMessage (Just "The input is invalid")
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.withError True
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with requiredness)" Label.InputLabel
                         |> Label.withRequirednessHint (Just (Label.Mandatory .no))
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with requiredness)" Label.InputLabel
                         |> Label.withRequirednessHint (Just (Label.Optional .no))
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.withError True
                                 |> TextInput.view []
                             ]
                     , Label.init "Customer name (with max char counter view)" Label.InputLabel
-                        |> Label.withCharCounter (Just { current = 4, max = 100 })
+                        |> Label.withCharCounter (Just { current = String.length model.customModel.labelInputContent, max = 100 })
                         |> Label.view []
-                            [ TextInput.init "Text"
+                            [ TextInput.init model.customModel.labelInputContent
+                                |> TextInput.withOnInput LabelInputContentChange
                                 |> TextInput.view []
                             ]
                     ]

--- a/src/Nordea/Css.elm
+++ b/src/Nordea/Css.elm
@@ -3,6 +3,7 @@ module Nordea.Css exposing
     , colorToString
     , colorVariable
     , columnGap
+    , cssIf
     , displayContents
     , displayGrid
     , gap
@@ -262,3 +263,12 @@ overridableCss className styles =
     [ css [ Css.children [ Css.selector selector styles ] ]
     , class className
     ]
+
+
+cssIf : Bool -> Css.Style -> Css.Style
+cssIf enable style =
+    if enable then
+        style
+
+    else
+        Css.property "" ""


### PR DESCRIPTION
Currently Label doesn't reserve space for the error message resulting in a noticable UI jerk when the error message takes up new space. Fix this by reserving space for the error message using visibility: hidden, also only do this if withError is used to avoid noticeable changes for other users.

Also 
- Enhance stories so that the problem can be reproduced in-tree.
- Add a cssIf helper, couldn't find anything matching this; holler if you know an existing implementation!

## UI Jerk in action
https://github.com/user-attachments/assets/bd27f029-4018-415c-b3c2-3e6817565fb4

