### PR TITLE
Mini flatlink should use small button size

### DIFF
--- a/src/Nordea/Components/FlatLink.elm
+++ b/src/Nordea/Components/FlatLink.elm
@@ -92,7 +92,16 @@ withDisabled (FlatLink config) =
 
 withButtonStyle : Button.Variant -> FlatLink -> FlatLink
 withButtonStyle buttonVariant (FlatLink config) =
-    FlatLink { config | styles = buttonStyle buttonVariant }
+    let
+        buttonSize =
+            case config.variant of
+                Default ->
+                    Button.Standard
+
+                Mini ->
+                    Button.Small
+    in
+    FlatLink { config | styles = buttonStyle buttonVariant buttonSize }
 
 
 
@@ -202,9 +211,9 @@ variantStyle variant =
                 ]
 
 
-buttonStyle : Button.Variant -> List Style
-buttonStyle buttonVariant =
+buttonStyle : Button.Variant -> Button.Size -> List Style
+buttonStyle buttonVariant buttonSize =
     [ maxWidth fitContent
     , textDecoration none
-    , Button.buttonStyleForExport buttonVariant Button.Standard
+    , Button.buttonStyleForExport buttonVariant buttonSize
     ]


### PR DESCRIPTION
Flatlink with `Mini` variant should use styles of button size `small`. 