### PR TITLE
Introduce helper to opt out of reserving space for errors on labels

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -49,6 +49,7 @@ type alias InputProperties =
     , labelType : LabelType
     , requirednessHint : Maybe RequirednessHint
     , errorMessage : Maybe String
+    , withError : Bool
     , reserveSpaceForError : Bool
     , hintText : Maybe String
     , charCounter : Maybe CharCounter
@@ -72,7 +73,8 @@ init labelText labelType =
         , labelType = labelType
         , requirednessHint = Nothing
         , errorMessage = Nothing
-        , reserveSpaceForError = False
+        , withError = False
+        , reserveSpaceForError = True
         , hintText = Nothing
         , charCounter = Nothing
         , size = Standard
@@ -140,7 +142,7 @@ view attrs children (Label config) =
                             [ String.fromInt counter.current ++ "/" ++ String.fromInt counter.max |> Html.text ]
 
                 showErrorRow =
-                    config.errorMessage /= Nothing || config.reserveSpaceForError
+                    config.withError && config.reserveSpaceForError
             in
             Html.row
                 (css
@@ -252,7 +254,7 @@ withRequirednessHint requirednessHint (Label config) =
 
 withErrorMessage : Maybe String -> Label -> Label
 withErrorMessage errorMessage (Label config) =
-    Label { config | errorMessage = errorMessage, reserveSpaceForError = True }
+    Label { config | errorMessage = errorMessage, withError = True }
 
 
 withNoReservedErrorSpace : Label -> Label

--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -255,8 +255,8 @@ withErrorMessage errorMessage (Label config) =
     Label { config | errorMessage = errorMessage, reserveSpaceForError = True }
 
 
-withNoReservedErrorSpace : Bool -> Label -> Label
-withNoReservedErrorSpace reserveSpace (Label config) =
+withNoReservedErrorSpace : Label -> Label
+withNoReservedErrorSpace (Label config) =
     Label { config | reserveSpaceForError = False }
 
 

--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -48,7 +48,6 @@ type alias InputProperties =
     , labelType : LabelType
     , requirednessHint : Maybe RequirednessHint
     , errorMessage : Maybe String
-    , withError : Bool
     , hintText : Maybe String
     , charCounter : Maybe CharCounter
     , size : Size
@@ -71,7 +70,6 @@ init labelText labelType =
         , labelType = labelType
         , requirednessHint = Nothing
         , errorMessage = Nothing
-        , withError = False
         , hintText = Nothing
         , charCounter = Nothing
         , size = Standard
@@ -119,17 +117,14 @@ view attrs children (Label config) =
                     initText config.size
                         |> Text.view [ css [ color Colors.darkGray ] ] [ Html.text text ]
 
-                viewError maybeError =
+                viewError error =
                     initText config.size
                         |> Text.view
                             [ class "input-focus-color"
-                            , css
-                                [ displayFlex
-                                , visibility hidden |> Css.cssIf (Maybe.isNothing maybeError)
-                                ]
+                            , css [ displayFlex ]
                             ]
                             [ Icons.error [ css [ marginRight (rem 0.5), flex none ] ]
-                            , maybeError |> Maybe.withDefault "No errors" |> Html.text
+                            , Html.text error
                             ]
 
                 viewCharCounter counter =
@@ -146,12 +141,12 @@ view attrs children (Label config) =
                     :: attrs_
                 )
                 [ Html.column []
-                    [ viewError config.errorMessage |> Html.showIf config.withError
+                    [ Html.viewMaybe viewError config.errorMessage
                     , config.hintText |> Html.viewMaybe viewHintText
                     ]
                 , config.charCounter |> Html.viewMaybe viewCharCounter
                 ]
-                |> showIf (config.withError || config.hintText /= Nothing || config.charCounter /= Nothing)
+                |> showIf (config.errorMessage /= Nothing || config.hintText /= Nothing || config.charCounter /= Nothing)
     in
     case config.labelType of
         InputLabel ->
@@ -248,7 +243,7 @@ withRequirednessHint requirednessHint (Label config) =
 
 withErrorMessage : Maybe String -> Label -> Label
 withErrorMessage errorMessage (Label config) =
-    Label { config | errorMessage = errorMessage, withError = True }
+    Label { config | errorMessage = errorMessage }
 
 
 withHintText : Maybe String -> Label -> Label


### PR DESCRIPTION
## Edit

Introduce a `Label.withNoReservedErrorSpace` for opting out of the current behaviour that reserves space below the Label component if using `Label.withErrorMessage Nothing`

---

When using `Label.withErrorMessage`, the Label component reserves space for the error message, even if the provided error message is `Nothing`. This makes it difficult to control spacing between components in a form.

I'm not sure if this behaviour is a feature or a bug. This PR proposes a bugfix.

## Current behaviour

### ✅ No error message:

Works as expected.

```elm
Label.init "No error message" Label.InputLabel
```

<img width="350" alt="image" src="https://github.com/user-attachments/assets/af19821f-b8c3-4e13-9f60-bb9c8f1bc079" />

### ✅ With error message = Just "Message"

Works as expected.

```elm
Label.init "With error message" Label.InputLabel
    |> Label.withErrorMessage (Just "Message")
```

<img width="350" alt="image" src="https://github.com/user-attachments/assets/42604c11-ef0d-4c70-acdc-7042a8d2e1c8" />

### ❌ With error message = Nothing

Notice the extra space between the second and third field.

```elm
Label.init "With empty error message" Label.InputLabel
    |> Label.withErrorMessage Nothing
```

<img width="351" alt="image" src="https://github.com/user-attachments/assets/62144f89-a367-4092-a9fc-e09d70da978f" />

## Proposed behaviour

### ✅ With error message = Nothing

No extra space between the second and third component when using `Label.withErrorMessage Nothing`.

<img width="353" alt="image" src="https://github.com/user-attachments/assets/11fe3231-fbcc-44f5-9ffa-a0e608675f34" />