### PR TITLE
Add builder methods to NumberInput for alignment and suffix

### DIFF
--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -72,7 +72,6 @@ stories =
           , \_ ->
                 NumberInput.init "123456"
                     |> NumberInput.withLeftAlignment
-                    |> NumberInput.withSmallSize
                     |> NumberInput.withPctSuffix
                     |> NumberInput.view []
           , {}

--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -73,7 +73,7 @@ stories =
                 NumberInput.init "123456"
                     |> NumberInput.withLeftAlignment
                     |> NumberInput.withSmallSize
-                    |> NumberInput.withKrSuffix
+                    |> NumberInput.withPctSuffix
                     |> NumberInput.view []
           , {}
           )

--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -53,4 +53,28 @@ stories =
                     |> NumberInput.view []
           , {}
           )
+        , ( "With left align"
+          , \_ ->
+                NumberInput.init "123456"
+                    |> NumberInput.withLeftAlignment
+                    |> NumberInput.view []
+          , {}
+          )
+        , ( "With left align and suffix"
+          , \_ ->
+                NumberInput.init "123456"
+                    |> NumberInput.withLeftAlignment
+                    |> NumberInput.withKrSuffix
+                    |> NumberInput.view []
+          , {}
+          )
+        , ( "With left align and small and suffix"
+          , \_ ->
+                NumberInput.init "123456"
+                    |> NumberInput.withLeftAlignment
+                    |> NumberInput.withSmallSize
+                    |> NumberInput.withKrSuffix
+                    |> NumberInput.view []
+          , {}
+          )
         ]

--- a/explorer/src/Stories/NumberInput.elm
+++ b/explorer/src/Stories/NumberInput.elm
@@ -60,7 +60,7 @@ stories =
                     |> NumberInput.view []
           , {}
           )
-        , ( "With left align and suffix"
+        , ( "With left align and kr suffix"
           , \_ ->
                 NumberInput.init "123456"
                     |> NumberInput.withLeftAlignment
@@ -68,7 +68,7 @@ stories =
                     |> NumberInput.view []
           , {}
           )
-        , ( "With left align and small and suffix"
+        , ( "With left align and pct suffix"
           , \_ ->
                 NumberInput.init "123456"
                     |> NumberInput.withLeftAlignment

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -16,12 +16,46 @@ module Nordea.Components.NumberInput exposing
     , withStep
     )
 
-import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, cursor, default, disabled, display, displayFlex, focus, fontSize, height, int, left, none, outline, padding4, pct, position, property, pseudoElement, relative, rem, right, solid, textAlign, width, zIndex)
+import Css
+    exposing
+        ( Style
+        , absolute
+        , alignItems
+        , backgroundColor
+        , border3
+        , borderBox
+        , borderRadius
+        , boxSizing
+        , center
+        , color
+        , cursor
+        , default
+        , disabled
+        , display
+        , displayFlex
+        , focus
+        , fontSize
+        , height
+        , left
+        , none
+        , outline
+        , padding4
+        , pct
+        , position
+        , property
+        , pseudoElement
+        , relative
+        , rem
+        , right
+        , solid
+        , textAlign
+        , width
+        )
 import Html.Styled as Html exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (css, placeholder, step, type_, value)
 import Html.Styled.Events exposing (onBlur, onInput)
 import Maybe.Extra as Maybe
-import Nordea.Resources.Colors as Colors
+import Nordea.Resources.Colors as Colors exposing (nordeaGray)
 import Nordea.Themes as Themes
 
 
@@ -168,7 +202,9 @@ view attributes (NumberInput config) =
                 ([ position absolute
                  , right (rem 0.5)
                  , cursor default
-                 , zIndex (int 99) --otherwise invisible on focus
+
+                 --    , zIndex (int 99) --otherwise invisible on focus
+                 , color nordeaGray
                  ]
                     ++ getFontSize config.size
                 )
@@ -230,7 +266,7 @@ getStyles config =
                     1.5
 
                 Just Pct ->
-                    1
+                    1.5
 
         sizeSpecificStyling =
             (case config.size of

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -16,7 +16,7 @@ module Nordea.Components.NumberInput exposing
     , withStep
     )
 
-import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, cursor, default, disabled, display, displayFlex, focus, fontSize, height, left, none, outline, padding4, pct, position, property, pseudoElement, relative, rem, right, solid, textAlign, width)
+import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, cursor, default, disabled, display, displayFlex, focus, fontSize, height, int, left, none, outline, padding4, pct, position, property, pseudoElement, relative, rem, right, solid, textAlign, width, zIndex)
 import Html.Styled as Html exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (css, placeholder, step, type_, value)
 import Html.Styled.Events exposing (onBlur, onInput)
@@ -163,7 +163,17 @@ view attributes (NumberInput config) =
             (getStyles config)
             (getAttributes config ++ attributes)
             []
-        , Html.div [ css ([ position absolute, right (rem 0.5), cursor default ] ++ getFontSize config.size) ] [ Html.text (config.suffix |> Maybe.map toString |> Maybe.withDefault "") ]
+        , Html.div
+            [ css
+                ([ position absolute
+                 , right (rem 0.5)
+                 , cursor default
+                 , zIndex (int 99) --otherwise invisible on focus
+                 ]
+                    ++ getFontSize config.size
+                )
+            ]
+            [ Html.text (config.suffix |> Maybe.map toString |> Maybe.withDefault "") ]
         ]
 
 

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -168,8 +168,6 @@ view attributes (NumberInput config) =
                 ([ position absolute
                  , right (rem 0.5)
                  , cursor default
-
-                 --    , zIndex (int 99) --otherwise invisible on focus
                  , color nordeaGray
                  ]
                     ++ getFontSize config.size

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -4,18 +4,21 @@ module Nordea.Components.NumberInput exposing
     , view
     , withError
     , withFormatter
+    , withKrSuffix
+    , withLeftAlignment
     , withMax
     , withMin
     , withOnBlur
     , withOnInput
+    , withPctSuffix
     , withPlaceholder
     , withSmallSize
     , withStep
     )
 
-import Css exposing (Style, backgroundColor, border3, borderBox, borderRadius, boxSizing, disabled, display, focus, fontSize, height, none, outline, padding2, pct, property, pseudoElement, rem, right, solid, textAlign, width)
-import Html.Styled exposing (Attribute, Html, input, styled)
-import Html.Styled.Attributes as Attributes exposing (placeholder, step, type_, value)
+import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, cursor, default, disabled, display, displayFlex, focus, fontSize, height, left, none, outline, padding4, pct, position, property, pseudoElement, relative, rem, right, solid, textAlign, width)
+import Html.Styled as Html exposing (Attribute, Html, input, styled)
+import Html.Styled.Attributes as Attributes exposing (css, placeholder, step, type_, value)
 import Html.Styled.Events exposing (onBlur, onInput)
 import Maybe.Extra as Maybe
 import Nordea.Resources.Colors as Colors
@@ -37,7 +40,29 @@ type alias Config msg =
     , onBlur : Maybe msg
     , formatter : Maybe (Float -> String)
     , size : Size
+    , alignment : Alignment
+    , suffix : Maybe Suffix
     }
+
+
+type Suffix
+    = Kr
+    | Pct
+
+
+toString : Suffix -> String
+toString suffix =
+    case suffix of
+        Kr ->
+            "KR"
+
+        Pct ->
+            "%"
+
+
+type Alignment
+    = Left
+    | Right
 
 
 type Size
@@ -62,6 +87,8 @@ init value =
         , onBlur = Nothing
         , formatter = Nothing
         , size = Standard
+        , alignment = Right
+        , suffix = Nothing
         }
 
 
@@ -110,16 +137,34 @@ withSmallSize (NumberInput config) =
     NumberInput { config | size = Small }
 
 
+withLeftAlignment : NumberInput msg -> NumberInput msg
+withLeftAlignment (NumberInput config) =
+    NumberInput { config | alignment = Left }
+
+
+withPctSuffix : NumberInput msg -> NumberInput msg
+withPctSuffix (NumberInput config) =
+    NumberInput { config | suffix = Just Pct }
+
+
+withKrSuffix : NumberInput msg -> NumberInput msg
+withKrSuffix (NumberInput config) =
+    NumberInput { config | suffix = Just Kr }
+
+
 
 -- VIEW
 
 
 view : List (Attribute msg) -> NumberInput msg -> Html msg
 view attributes (NumberInput config) =
-    styled input
-        (getStyles config)
-        (getAttributes config ++ attributes)
-        []
+    Html.div [ css [ position relative, displayFlex, alignItems center ] ]
+        [ styled input
+            (getStyles config)
+            (getAttributes config ++ attributes)
+            []
+        , Html.div [ css ([ position absolute, right (rem 0.5), cursor default ] ++ getFontSize config.size) ] [ Html.text (config.suffix |> Maybe.map toString |> Maybe.withDefault "") ]
+        ]
 
 
 getAttributes : Config msg -> List (Attribute msg)
@@ -166,24 +211,43 @@ getStyles config =
             else
                 Colors.mediumGray
 
+        rightPaddingAdditionDueToIcon =
+            case config.suffix of
+                Nothing ->
+                    0
+
+                Just Kr ->
+                    1.5
+
+                Just Pct ->
+                    1
+
         sizeSpecificStyling =
-            case config.size of
+            (case config.size of
                 Small ->
-                    [ fontSize (rem 0.75)
-                    , height (rem 1.5)
-                    , padding2 (rem 0.25) (rem 0.5)
+                    [ height (rem 1.5)
+                    , padding4 (rem 0.25) (rem (0.5 + rightPaddingAdditionDueToIcon)) (rem 0.25) (rem 0.5)
                     ]
 
                 Standard ->
-                    [ fontSize (rem 1)
-                    , height (rem 2.5)
-                    , padding2 (rem 0) (rem 0.75)
+                    [ height (rem 2.5)
+                    , padding4 (rem 0) (rem (0.75 + rightPaddingAdditionDueToIcon)) (rem 0) (rem 0.75)
                     ]
+            )
+                ++ getFontSize config.size
+
+        textAlignValue =
+            case config.alignment of
+                Left ->
+                    left
+
+                Right ->
+                    right
     in
     [ pseudoElement "-webkit-outer-spin-button" [ display none ]
     , pseudoElement "-webkit-inner-spin-button" [ display none ]
     , property "-moz-appearance" "textfield"
-    , textAlign right
+    , textAlign textAlignValue
     , borderRadius (rem 0.25)
     , border3 (rem 0.0625) solid borderColorStyle
     , boxSizing borderBox
@@ -195,3 +259,13 @@ getStyles config =
         ]
     ]
         ++ sizeSpecificStyling
+
+
+getFontSize : Size -> List Style
+getFontSize size =
+    case size of
+        Small ->
+            [ fontSize (rem 0.75) ]
+
+        Standard ->
+            [ fontSize (rem 1) ]

--- a/src/Nordea/Components/NumberInput.elm
+++ b/src/Nordea/Components/NumberInput.elm
@@ -16,41 +16,7 @@ module Nordea.Components.NumberInput exposing
     , withStep
     )
 
-import Css
-    exposing
-        ( Style
-        , absolute
-        , alignItems
-        , backgroundColor
-        , border3
-        , borderBox
-        , borderRadius
-        , boxSizing
-        , center
-        , color
-        , cursor
-        , default
-        , disabled
-        , display
-        , displayFlex
-        , focus
-        , fontSize
-        , height
-        , left
-        , none
-        , outline
-        , padding4
-        , pct
-        , position
-        , property
-        , pseudoElement
-        , relative
-        , rem
-        , right
-        , solid
-        , textAlign
-        , width
-        )
+import Css exposing (Style, absolute, alignItems, backgroundColor, border3, borderBox, borderRadius, boxSizing, center, color, cursor, default, disabled, display, displayFlex, focus, fontSize, height, left, none, outline, padding4, pct, position, property, pseudoElement, relative, rem, right, solid, textAlign, width)
 import Html.Styled as Html exposing (Attribute, Html, input, styled)
 import Html.Styled.Attributes as Attributes exposing (css, placeholder, step, type_, value)
 import Html.Styled.Events exposing (onBlur, onInput)


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/95c75a52-5b8c-481f-875a-5ce2dba394ab)

![image](https://github.com/user-attachments/assets/c50abfff-ce66-4765-9679-363cb6768dc1)


Added options for
- Aligning the text to left
- Using "KR" or "%" suffixes.