### PR TITLE
Improve blue contrast in chat component

### DIFF
--- a/src/Nordea/Components/Chat.elm
+++ b/src/Nordea/Components/Chat.elm
@@ -183,14 +183,13 @@ chatHistoryView attrs { sentFrom, sentAt, sender, message, isIncomingMessage, re
             if isIncomingMessage then
                 Css.batch
                     [ borderRadius4 (rem 0.5) (rem 0.5) (rem 0.5) (rem 0)
-                    , Themes.color Colors.white
-                    , Themes.backgroundColor Colors.nordeaBlue
+                    , Themes.backgroundColor Colors.coolGray
                     ]
 
             else
                 Css.batch
                     [ borderRadius4 (rem 0.5) (rem 0.5) (rem 0) (rem 0.5)
-                    , Themes.backgroundColor Colors.coolGray
+                    , Themes.backgroundColor Colors.cloudBlue
                     ]
 
         messageLabel attr text =


### PR DESCRIPTION
Using lighter blue shade (cloudBlue) now. Also, changed to use brighter shade for users message and lighter one for incoming messages. Since it is the standard used in other messaging services 

![image](https://github.com/user-attachments/assets/b2beb9a1-b904-42e3-a73c-5006b2e476fa)

https://www.figma.com/design/wErdj7sE82qBlsDe05HA4s/SketchHub?node-id=8792-35801&t=99P6tkDFTewsItD1-0
