### PR TITLE
Group label bottom margin fix

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -188,7 +188,7 @@ view attrs children (Label config) =
                     [ css
                         [ padding (rem 0)
                         , width (pct 100)
-                        , Css.Global.children [ everything [ flexBasis (pct 100) ] ]
+                        , Css.Global.children [ everything [ flexBasis (pct 100), marginBottom (rem 0) ] ]
                         ]
                     ]
                     [ topInfo ]


### PR DESCRIPTION
Fixed a small bottom margin difference between InputLabel and GroupLabel.

Before:
![image](https://github.com/user-attachments/assets/7b5db3c5-f909-4f67-9c1e-1d47b50a4f76)

After :fire::
![image](https://github.com/user-attachments/assets/0086d9d4-5463-4d7b-bb45-716a9b83237d)
