### PR TITLE
Revert "Group label bottom margin fix"

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -188,7 +188,7 @@ view attrs children (Label config) =
                     [ css
                         [ padding (rem 0)
                         , width (pct 100)
-                        , Css.Global.children [ everything [ flexBasis (pct 100), marginBottom (rem 0) ] ]
+                        , Css.Global.children [ everything [ flexBasis (pct 100) ] ]
                         ]
                     ]
                     [ topInfo ]


### PR DESCRIPTION
Reverts SGFinansAS/elm-components#458


Reverting this since it other than input fields combined with group label looked off.