### PR TITLE
Add groups to multiselect

### DIFF
--- a/explorer/src/Stories/MultiSelectDropdown.elm
+++ b/explorer/src/Stories/MultiSelectDropdown.elm
@@ -27,4 +27,27 @@ stories =
                     |> MultiSelectDropdown.view []
           , {}
           )
+        , ( "With groups"
+          , \model ->
+                MultiSelectDropdown.init { onFocus = FocusMultiSelectDropdown }
+                    |> MultiSelectDropdown.withLabel "Label"
+                    |> MultiSelectDropdown.withPlaceholder "Choose an option"
+                    |> MultiSelectDropdown.withHasFocus model.customModel.hasMultiSelectDropdownFocus
+                    |> MultiSelectDropdown.withRequirednessHint (Just (Label.Mandatory .no))
+                    |> MultiSelectDropdown.withOptionGroups
+                        [ { options =
+                                [ { name = "1", label = "Valg 1", isChecked = model.customModel.isChoice1, onCheck = \_ -> OnCheckChoice1 }
+                                , { name = "2", label = "Valg 2", isChecked = model.customModel.isChoice2, onCheck = \_ -> OnCheckChoice2 }
+                                ]
+                          , groupLabel = Just "Group 1"
+                          }
+                        , { options =
+                                [ { name = "3", label = "Valg 3", isChecked = model.customModel.isChoice3, onCheck = \_ -> OnCheckChoice3 }
+                                ]
+                          , groupLabel = Just "Group 2"
+                          }
+                        ]
+                    |> MultiSelectDropdown.view []
+          , {}
+          )
         ]

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -11,8 +11,7 @@ module Nordea.Components.MultiSelectDropdown exposing
     , withRequirednessHint
     )
 
-import Css exposing (absolute, alignItems, backgroundColor, border3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderRadius4, boxSizing, center, color, column, cursor, display, displayFlex, flexDirection, height, hover, int, justifyContent, left, listStyle, margin, marginLeft, marginTop, maxHeight, none, overflowY, padding, padding4, paddingTop, pct, pointer, position, relative, rem, right, scroll, solid, spaceBetween, start, top, width, zIndex)
-import Html.Attributes.Extra as Attributes
+import Css exposing (absolute, alignItems, backgroundColor, border3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderRadius4, boxSizing, center, color, column, cursor, display, displayFlex, flexDirection, height, hover, int, justifyContent, left, listStyle, margin, marginLeft, marginTop, maxHeight, none, overflowY, padding, padding4, pct, pointer, position, relative, rem, right, scroll, solid, spaceBetween, start, top, width, zIndex)
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css, tabindex)
 import Html.Styled.Events as Events


### PR DESCRIPTION
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/849511ac-1dd4-4dbd-9426-1682f1da6ad5" />

Adds groups to multiselectdropdown. See design on left.

I have not changed the actual design and spacing of the select items, so it is not 100% as the design.

I have kept the current withOptions-functions, so it should be non-breaking
