### PR TITLE
MultiCompanySelector - add selected before input

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
     "elm/file": "1.0.5 <= v < 2.0.0",
     "elm/json": "1.1.3 <= v < 2.0.0",
     "elm/time": "1.0.0 <= v < 2.0.0",
+    "elm/browser": "1.0.2 <= v < 1.0.3",
     "elm-community/html-extra": "3.4.0 <= v < 4.0.0",
     "elm-community/list-extra": "8.2.4 <= v < 9.0.0",
     "elm-community/maybe-extra": "5.2.0 <= v < 6.0.0",

--- a/explorer/elm.json
+++ b/explorer/elm.json
@@ -7,6 +7,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/file": "1.0.5",
             "elm/html": "1.0.0",
@@ -26,7 +27,6 @@
             "1602/elm-feather": "2.3.4",
             "NoRedInk/datetimepicker-legacy": "1.0.4",
             "avh4/elm-debug-controls": "2.2.1",
-            "elm/browser": "1.0.2",
             "elm/bytes": "1.0.8",
             "elm/http": "2.0.0",
             "elm/parser": "1.1.0",

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -37,6 +37,7 @@ type alias Config =
     , isChoice1 : Bool
     , isChoice2 : Bool
     , isChoice3 : Bool
+    , selectedItems : List String
     , searchHasFocus : Bool
     , isFeatureBoxOpen : Bool
     , isProgressBarCompleted : Bool
@@ -144,6 +145,7 @@ init =
     , currentDatePickerValue = Nothing
     , isCardOpen = True
     , fiveStarRating = 0
+    , selectedItems = []
     }
 
 
@@ -192,13 +194,13 @@ update msg config =
             { config | hasMultiSelectDropdownFocus = value }
 
         OnCheckChoice1 ->
-            { config | isChoice1 = not config.isChoice1 }
+            { config | isChoice1 = not config.isChoice1, selectedItems = "Valg 1" :: config.selectedItems }
 
         OnCheckChoice2 ->
-            { config | isChoice2 = not config.isChoice2 }
+            { config | isChoice2 = not config.isChoice2, selectedItems = "Valg 2" :: config.selectedItems }
 
         OnCheckChoice3 ->
-            { config | isChoice3 = not config.isChoice3 }
+            { config | isChoice3 = not config.isChoice3, selectedItems = "Valg 3" :: config.selectedItems }
 
         SearchComponentSelected item ->
             { config

--- a/explorer/src/Config.elm
+++ b/explorer/src/Config.elm
@@ -68,6 +68,7 @@ type Msg
     | AccordionTableAllRowsChecked Bool
     | AccordionTableRowChecked Int Bool
     | SearchComponentInput String
+    | SearchComponentInputWithCmd String (Cmd Msg)
     | SearchComponentSelected (Maybe (Item FinancingVariant))
     | SearchComponentSelectedOrgInfo (Maybe (Item OrganizationInfo))
     | SearchComponentFocus Bool
@@ -149,11 +150,16 @@ init =
     }
 
 
-update : Msg -> Config -> Config
+addCmdNone m =
+    ( m, Cmd.none )
+
+
+update : Msg -> Config -> ( Config, Cmd Msg )
 update msg config =
     case msg of
         AccordionMsg m ->
             { config | accordion = Accordion.update m config.accordion }
+                |> addCmdNone
 
         AccordionTableRowToggled index isOpen ->
             let
@@ -165,6 +171,7 @@ update msg config =
                         Set.remove
             in
             { config | openAccordionTableRows = operation index config.openAccordionTableRows }
+                |> addCmdNone
 
         AccordionTableAllRowsChecked areChecked ->
             { config
@@ -175,6 +182,7 @@ update msg config =
                     else
                         Set.empty
             }
+                |> addCmdNone
 
         AccordionTableRowChecked index isChecked ->
             let
@@ -186,21 +194,30 @@ update msg config =
                         Set.remove
             in
             { config | selectedAccordionTableRows = operation index config.selectedAccordionTableRows }
+                |> addCmdNone
 
         SearchComponentInput input ->
             { config | searchComponentInput = input }
+                |> addCmdNone
+
+        SearchComponentInputWithCmd input cmd ->
+            ( { config | searchComponentInput = input }, cmd )
 
         FocusMultiSelectDropdown value ->
             { config | hasMultiSelectDropdownFocus = value }
+                |> addCmdNone
 
         OnCheckChoice1 ->
             { config | isChoice1 = not config.isChoice1, selectedItems = "Valg 1" :: config.selectedItems }
+                |> addCmdNone
 
         OnCheckChoice2 ->
             { config | isChoice2 = not config.isChoice2, selectedItems = "Valg 2" :: config.selectedItems }
+                |> addCmdNone
 
         OnCheckChoice3 ->
             { config | isChoice3 = not config.isChoice3, selectedItems = "Valg 3" :: config.selectedItems }
+                |> addCmdNone
 
         SearchComponentSelected item ->
             { config
@@ -208,6 +225,7 @@ update msg config =
                 , selectedSearchComponent = item
                 , searchHasFocus = False
             }
+                |> addCmdNone
 
         SearchComponentSelectedOrgInfo item ->
             { config
@@ -215,60 +233,79 @@ update msg config =
                 , selectedSearchComponentOrgInfo = item |> Maybe.map .value
                 , searchHasFocus = False
             }
+                |> addCmdNone
 
         SearchComponentFocus value ->
             { config | searchHasFocus = value }
+                |> addCmdNone
 
         NoOp ->
             config
+                |> addCmdNone
 
         ToggleModal ->
             { config | isModalOpen = not config.isModalOpen }
+                |> addCmdNone
 
         ToggleFeatureBox ->
             { config | isFeatureBoxOpen = not config.isFeatureBoxOpen }
+                |> addCmdNone
 
         ToggleProgressBarCompleted ->
             { config | isProgressBarCompleted = not config.isProgressBarCompleted }
+                |> addCmdNone
 
         OnDragEnterFileUpload ->
             { config | isHoveringFileUpload = True }
+                |> addCmdNone
 
         OnDragLeaveFileUpload ->
             { config | isHoveringFileUpload = False }
+                |> addCmdNone
 
         OnFilesSelected files ->
             { config | selectedFiles = files ++ config.selectedFiles, isHoveringFileUpload = False }
+                |> addCmdNone
 
         RemoveFile file ->
             { config | selectedFiles = config.selectedFiles |> List.filter ((/=) file) }
+                |> addCmdNone
 
         SliderMsg value ->
             { config | sliderInputValue = value }
+                |> addCmdNone
 
         RangeMsg value ->
             { config | rangeInputValue = value }
+                |> addCmdNone
 
         ToggleToggle ->
             { config | isToggled = not config.isToggled }
+                |> addCmdNone
 
         ToggleHamburger ->
             { config | hamburgerIsActive = not config.hamburgerIsActive }
+                |> addCmdNone
 
         UpdateCoachmarkStep p ->
             { config | showCoachMarkStep = p }
+                |> addCmdNone
 
         UpdateActiveRadioButton s ->
             { config | activeRadioButton = s }
+                |> addCmdNone
 
         TextInputContentChange string ->
             { config | textInputContent = string }
+                |> addCmdNone
 
         LabelInputContentChange string ->
             { config | labelInputContent = string }
+                |> addCmdNone
 
         OnClickCollapsible ->
             config
+                |> addCmdNone
 
         SortableTableMsg tableMsg ->
             case tableMsg of
@@ -286,24 +323,31 @@ update msg config =
                                     { column = column, order = Stories.SortableTableSharedTypes.Desc }
                     in
                     { config | sortableTable = updatedModel }
+                        |> addCmdNone
 
         SnackbarMsg ->
             config
+                |> addCmdNone
 
         PaginationClickedAt i ->
             { config | paginationCurrentPage = i }
+                |> addCmdNone
 
         DateSelected result datePickerState ->
             { config
                 | currentDatePickerValue = Just result
                 , datePicker = DatePicker.updateInternalState datePickerState config.datePicker
             }
+                |> addCmdNone
 
         UpdateDatePickerInternalState datePickerState ->
             { config | datePicker = DatePicker.updateInternalState datePickerState config.datePicker }
+                |> addCmdNone
 
         SetRating value ->
             { config | fiveStarRating = value }
+                |> addCmdNone
 
         ToggleOpenCard ->
             { config | isCardOpen = not config.isCardOpen }
+                |> addCmdNone

--- a/explorer/src/Explorer.elm
+++ b/explorer/src/Explorer.elm
@@ -65,7 +65,11 @@ type alias Model =
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    ( { model | customModel = Config.update msg model.customModel }, Cmd.none )
+    let
+        ( customModel, cmd ) =
+            Config.update msg model.customModel
+    in
+    ( { model | customModel = customModel }, cmd )
 
 
 viewEnhancer : a -> Html msg -> Html msg

--- a/explorer/src/Stories/MultiSelectDropdown.elm
+++ b/explorer/src/Stories/MultiSelectDropdown.elm
@@ -1,6 +1,8 @@
 module Stories.MultiSelectDropdown exposing (stories)
 
 import Config exposing (Msg(..))
+import Css exposing (rem, width)
+import Html.Styled.Attributes exposing (css)
 import Maybe.Extra as Maybe
 import Nordea.Components.Label as Label
 import Nordea.Components.MultiSelectDropdown as MultiSelectDropdown
@@ -73,7 +75,7 @@ stories =
                           , groupLabel = Just "Group 2"
                           }
                         ]
-                    |> MultiSelectDropdown.view []
+                    |> MultiSelectDropdown.view [ css [ width (rem 40) ] ]
           , {}
           )
         , ( "With error (if input is non-empty)"

--- a/explorer/src/Stories/MultiSelectDropdown.elm
+++ b/explorer/src/Stories/MultiSelectDropdown.elm
@@ -61,7 +61,7 @@ stories =
                     |> MultiSelectDropdown.withHasFocus model.customModel.hasMultiSelectDropdownFocus
                     |> MultiSelectDropdown.withRequirednessHint (Just (Label.Mandatory .no))
                     |> MultiSelectDropdown.withHintText (Just "Hint")
-                    |> MultiSelectDropdown.withInput model.customModel.searchComponentInput SearchComponentInput "inputId"
+                    |> MultiSelectDropdown.withInput model.customModel.searchComponentInput SearchComponentInputWithCmd NoOp "inputId"
                     |> MultiSelectDropdown.withOptionGroups
                         [ { options =
                                 [ { name = "1", label = "Valg 1", isChecked = model.customModel.isChoice1, onCheck = \_ -> OnCheckChoice1 }
@@ -85,7 +85,7 @@ stories =
                     |> MultiSelectDropdown.withPlaceholder "Choose an option or type"
                     |> MultiSelectDropdown.withHasFocus model.customModel.hasMultiSelectDropdownFocus
                     |> MultiSelectDropdown.withRequirednessHint (Just (Label.Mandatory .no))
-                    |> MultiSelectDropdown.withInput model.customModel.searchComponentInput SearchComponentInput "inputId"
+                    |> MultiSelectDropdown.withInput model.customModel.searchComponentInput SearchComponentInputWithCmd NoOp "inputId"
                     |> MultiSelectDropdown.withError (Just model.customModel.searchComponentInput |> Maybe.filter (String.isEmpty >> not))
                     |> MultiSelectDropdown.withOptionGroups
                         [ { options =

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -14,7 +14,7 @@ module Nordea.Components.MultiSelectDropdown exposing
     , withSelected
     )
 
-import Css exposing (absolute, alignItems, auto, backgroundColor, border3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderRadius, borderRadius4, borderStyle, boxShadow, boxSizing, center, color, column, cursor, display, displayFlex, flexBasis, flexDirection, flexGrow, flexWrap, fontSize, height, hover, important, int, justifyContent, left, listStyle, margin, marginLeft, marginTop, maxHeight, minWidth, noWrap, none, num, outline, overflowY, padding, padding2, padding4, paddingLeft, pct, pointer, pointerEvents, position, relative, rem, right, scroll, solid, spaceBetween, start, top, whiteSpace, width, wrap, zIndex)
+import Css exposing (absolute, alignItems, backgroundColor, border3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderRadius, borderRadius4, borderStyle, boxShadow, boxSizing, center, color, column, cursor, display, displayFlex, flexBasis, flexDirection, flexGrow, flexWrap, fontSize, height, hover, important, int, justifyContent, left, listStyle, margin, marginLeft, marginTop, maxHeight, minWidth, noWrap, none, num, outline, overflowY, padding, padding2, padding4, paddingLeft, pct, pointer, pointerEvents, position, relative, rem, right, scroll, solid, spaceBetween, start, top, whiteSpace, width, wrap, zIndex)
 import Html.Styled as Html exposing (Attribute, Html, div, input, span, text)
 import Html.Styled.Attributes as Attrs exposing (css, placeholder, tabindex, value)
 import Html.Styled.Events as Events exposing (onClick, onInput)
@@ -25,7 +25,7 @@ import Nordea.Components.Label as Label exposing (RequirednessHint)
 import Nordea.Components.OutsideEventSupport as OutsideEventSupport
 import Nordea.Components.Text as Text
 import Nordea.Css exposing (gap)
-import Nordea.Html as Html exposing (attrEmpty, attrIf, styleIf)
+import Nordea.Html as Html exposing (attrEmpty, attrIf)
 import Nordea.Html.Events as Events
 import Nordea.Resources.Colors as Colors
 import Nordea.Resources.Icons as Icon

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -17,7 +17,7 @@ module Nordea.Components.MultiSelectDropdown exposing
 import Browser.Dom as Browser
 import Css exposing (absolute, alignItems, backgroundColor, border3, borderBottomLeftRadius, borderBottomRightRadius, borderBox, borderRadius, borderRadius4, borderStyle, boxShadow, boxSizing, center, color, column, cursor, display, displayFlex, flexBasis, flexDirection, flexGrow, flexWrap, fontSize, height, hover, important, int, justifyContent, left, listStyle, margin, marginLeft, marginTop, maxHeight, minWidth, noWrap, none, num, outline, overflowY, padding, padding2, padding4, paddingLeft, pct, pointer, pointerEvents, position, relative, rem, right, scroll, solid, spaceBetween, start, top, whiteSpace, width, wrap, zIndex)
 import Html.Styled as Html exposing (Attribute, Html, div, input, span, text)
-import Html.Styled.Attributes as Attrs exposing (class, css, id, placeholder, tabindex, value)
+import Html.Styled.Attributes as Attrs exposing (css, id, placeholder, tabindex, value)
 import Html.Styled.Events as Events exposing (onClick, onInput)
 import Json.Decode as Decode
 import Maybe.Extra as Maybe

--- a/src/Nordea/Components/MultiSelectDropdown.elm
+++ b/src/Nordea/Components/MultiSelectDropdown.elm
@@ -84,15 +84,6 @@ init { onFocus } =
     }
 
 
-focusInput : String -> msg -> Cmd msg
-focusInput id noOp =
-    Task.attempt (\_ -> noOp) (Browser.focus (makeId id))
-
-
-makeId s =
-    "multiselectinput" ++ s
-
-
 view : List (Attribute msg) -> MultiSelectDropdown msg -> Html msg
 view attrs dropdown =
     let
@@ -104,7 +95,7 @@ view attrs dropdown =
 
         viewInput inputProps =
             input
-                [ id (makeId inputProps.uniqueId)
+                [ id (makeId inputProps)
                 , css
                     [ outline none
                     , important (boxShadow none)
@@ -142,7 +133,7 @@ view attrs dropdown =
                     , gap (rem 0.5)
                     , width (pct 100)
                     ]
-                , onClick (inputProperties.onInput inputProperties.input (focusInput inputProperties.uniqueId inputProperties.noOp))
+                , onClick (inputProperties.onInput inputProperties.input (focusInput inputProperties))
                 ]
                 (List.concat
                     [ dropdown.optionGroups
@@ -394,6 +385,16 @@ viewSelectItems dropdown index orgOptionGroup =
                         (viewOptionGroup filteredOptionGroup)
                     ]
             )
+
+
+focusInput : InputProperties msg -> Cmd msg
+focusInput inputProperties =
+    Task.attempt (\_ -> inputProperties.noOp) (Browser.focus (makeId inputProperties))
+
+
+makeId : InputProperties msg -> String
+makeId inputProperties =
+    "multiselectinput" ++ inputProperties.uniqueId
 
 
 withLabel : String -> MultiSelectDropdown msg -> MultiSelectDropdown msg

--- a/src/Nordea/Html/Events.elm
+++ b/src/Nordea/Html/Events.elm
@@ -1,4 +1,4 @@
-module Nordea.Html.Events exposing (Key(..), onChange, onEnterOrSpacePress, onEnterPress, onEscPress, onKeyDown)
+module Nordea.Html.Events exposing (Key(..), onChange, onEnterOrSpacePress, onEnterPress, onEscPress, onKeyDown, onKeyDownMaybe)
 
 import Html.Styled exposing (Attribute)
 import Html.Styled.Events as Events
@@ -32,6 +32,35 @@ onKeyDown msg =
 
                         27 ->
                             Decode.succeed ( msg Esc, True )
+
+                        _ ->
+                            Decode.fail "Not space and enter"
+                )
+        )
+
+
+onKeyDownMaybe : (Key -> Maybe msg) -> Attribute msg
+onKeyDownMaybe msg =
+    -- prevent the space from moving the page
+    Events.preventDefaultOn "keydown"
+        (Events.keyCode
+            |> Decode.andThen
+                (\keyCode ->
+                    let
+                        try key =
+                            msg key
+                                |> Maybe.map (\keyMsg -> Decode.succeed ( keyMsg, True ))
+                                |> Maybe.withDefault (Decode.fail "Not relevant keypress")
+                    in
+                    case keyCode of
+                        32 ->
+                            try Space
+
+                        13 ->
+                            try Enter
+
+                        27 ->
+                            try Esc
 
                         _ ->
                             Decode.fail "Not space and enter"


### PR DESCRIPTION
Add the showing of the selected items, for the multiselect with filter. 
(Not implemented for the non search-filter version. that can be added later)

To fix input focus when clicking the non-input-row, i need to use Browser.Dom.focus from elm/browser. 


### Basic usage works as expected 
![2025-05-08 12 51 01](https://github.com/user-attachments/assets/50925b70-5434-4b08-b275-11d9f641d63d)

### Tabbing and space and click inside works with focus and such
![2025-05-08 12 51 29](https://github.com/user-attachments/assets/d3ef6eb5-c973-49cf-aa60-67853d034fd6)


### Break works fine wiht multiple 

<img width="747" alt="image" src="https://github.com/user-attachments/assets/a4ba46d8-7a13-4f1b-8767-2fdc3a82b0a4" />
