### PR TITLE
TextArea.withSmallSize

### DIFF
--- a/explorer/src/Stories/TextArea.elm
+++ b/explorer/src/Stories/TextArea.elm
@@ -50,6 +50,13 @@ stories =
                     |> TextArea.view []
           , {}
           )
+        , ( "Small"
+          , \_ ->
+                TextArea.init ""
+                    |> TextArea.withSmallSize
+                    |> TextArea.view []
+          , {}
+          )
         ]
 
 

--- a/src/Nordea/Components/TextArea.elm
+++ b/src/Nordea/Components/TextArea.elm
@@ -173,4 +173,3 @@ getStyles config =
                 , Themes.borderColor Colors.nordeaBlue
                 ]
            ]
-

--- a/src/Nordea/Components/TextArea.elm
+++ b/src/Nordea/Components/TextArea.elm
@@ -7,6 +7,7 @@ module Nordea.Components.TextArea exposing
     , withOnBlur
     , withOnInput
     , withPlaceholder
+    , withSmallSize
     )
 
 import Css
@@ -49,7 +50,13 @@ type alias Config msg =
     , showError : Bool
     , onBlur : Maybe msg
     , maxLength : Maybe Int
+    , size : Size
     }
+
+
+type Size
+    = Small
+    | Standard
 
 
 type TextArea msg
@@ -65,6 +72,7 @@ init value =
         , showError = False
         , onBlur = Nothing
         , maxLength = Nothing
+        , size = Standard
         }
 
 
@@ -91,6 +99,11 @@ withOnBlur onBlur (TextArea config) =
 withMaxLength : Int -> TextArea msg -> TextArea msg
 withMaxLength maxLength (TextArea config) =
     TextArea { config | maxLength = Just maxLength }
+
+
+withSmallSize : TextArea msg -> TextArea msg
+withSmallSize (TextArea config) =
+    TextArea { config | size = Small }
 
 
 
@@ -134,18 +147,30 @@ getStyles config =
 
             else
                 Colors.mediumGray
+
+        sizeSpecificStyling =
+            case config.size of
+                Small ->
+                    [ Fonts.fromSize 0.75
+                    , padding2 (rem 0.5) (rem 0.5)
+                    ]
+
+                Standard ->
+                    [ Fonts.fromSize 1
+                    , padding2 (rem 0.5) (rem 0.75)
+                    , lineHeight (rem 1.5)
+                    ]
     in
-    [ Fonts.fromSize 1
-    , padding2 (rem 0.5) (rem 0.75)
-    , borderRadius (rem 0.25)
-    , border3 (rem 0.0625) solid borderColorStyle
-    , boxSizing borderBox
-    , disabled [ backgroundColor Colors.grayWarm ]
-    , lineHeight (rem 1.5)
-    , resize none
-    , overflow auto
-    , focus
-        [ outline none
-        , Themes.borderColor Colors.nordeaBlue
-        ]
-    ]
+    sizeSpecificStyling
+        ++ [ borderRadius (rem 0.25)
+           , border3 (rem 0.0625) solid borderColorStyle
+           , boxSizing borderBox
+           , disabled [ backgroundColor Colors.grayWarm ]
+           , resize none
+           , overflow auto
+           , focus
+                [ outline none
+                , Themes.borderColor Colors.nordeaBlue
+                ]
+           ]
+


### PR DESCRIPTION
Add TextArea.withSmallSize. Took some inspiration from TextInput.withSmallSize


### :movie_camera: Elm explorer demo
[small-textarea.webm](https://github.com/user-attachments/assets/44413573-4131-4131-af6f-0f451108598c)
