### PR TITLE
Improve accessibility of text label

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -26,11 +26,7 @@ import Css
         , hidden
         , justifyContent
         , margin
-        , marginBlockEnd
-        , marginBlockStart
         , marginBottom
-        , marginInlineEnd
-        , marginInlineStart
         , marginRight
         , marginTop
         , none


### PR DESCRIPTION
Text labels can be semantically described with the definition list element: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl 