### PR TITLE
Remove 'withError' on label

### DIFF
--- a/src/Nordea/Components/Label.elm
+++ b/src/Nordea/Components/Label.elm
@@ -76,7 +76,6 @@ type alias InputProperties =
     , labelType : LabelType
     , requirednessHint : Maybe RequirednessHint
     , errorMessage : Maybe String
-    , withError : Bool
     , reserveSpaceForError : Bool
     , hintText : Maybe String
     , charCounter : Maybe CharCounter
@@ -100,7 +99,6 @@ init labelText labelType =
         , labelType = labelType
         , requirednessHint = Nothing
         , errorMessage = Nothing
-        , withError = False
         , reserveSpaceForError = True
         , hintText = Nothing
         , charCounter = Nothing
@@ -179,7 +177,7 @@ view attrs children (Label config) =
                             [ String.fromInt counter.current ++ "/" ++ String.fromInt counter.max |> Html.text ]
 
                 showErrorRow =
-                    config.withError && config.reserveSpaceForError
+                    Maybe.isJust config.errorMessage || config.reserveSpaceForError
             in
             Html.row
                 (css
@@ -294,7 +292,7 @@ withRequirednessHint requirednessHint (Label config) =
 
 withErrorMessage : Maybe String -> Label -> Label
 withErrorMessage errorMessage (Label config) =
-    Label { config | errorMessage = errorMessage, withError = True }
+    Label { config | errorMessage = errorMessage }
 
 
 withNoReservedErrorSpace : Label -> Label


### PR DESCRIPTION
The bool currently makes it hard to make a consistent layout when mixing form controls with and without errors.