### PR TITLE
Add accessibility label for progress bar stepper

### DIFF
--- a/explorer/src/Stories/ProgressBarStepper.elm
+++ b/explorer/src/Stories/ProgressBarStepper.elm
@@ -11,7 +11,7 @@ stories =
         "ProgressBarStepper"
         [ ( "Default"
           , \_ ->
-                ProgressBarStepper.init { steps = [ "Step 1", "Step 2", "Step 3", "Step 4", "Step 5" ], currentStep = 2, nextLabel = .no }
+                ProgressBarStepper.init { steps = [ "Step 1", "Step 2", "Step 3", "Step 4", "Step 5" ], currentStep = 2, translate = .no }
                     |> ProgressBarStepper.view []
           , {}
           )

--- a/src/Nordea/Components/ProgressBarStepper.elm
+++ b/src/Nordea/Components/ProgressBarStepper.elm
@@ -14,7 +14,7 @@ import Css
         , width
         )
 import Html.Styled as Html exposing (Attribute, Html)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes exposing (attribute, css)
 import List.Extra as List
 import Nordea.Components.ProgressBar as ProgressBar
 import Nordea.Components.Text as Text
@@ -26,26 +26,29 @@ import Nordea.Resources.I18N exposing (Translation)
 type alias ViewConfig =
     { steps : List String
     , currentStep : Int
-    , nextLabel : Translation -> String
+    , translate : Translation -> String
     }
 
 
-init : { r | steps : b, currentStep : c, nextLabel : d } -> { steps : b, currentStep : c, nextLabel : d }
-init { steps, currentStep, nextLabel } =
+init : { r | steps : b, currentStep : c, translate : d } -> { steps : b, currentStep : c, translate : d }
+init { steps, currentStep, translate } =
     { steps = steps
     , currentStep = currentStep
-    , nextLabel = nextLabel
+    , translate = translate
     }
 
 
 view : List (Attribute msg) -> ViewConfig -> Html msg
-view attrs { steps, currentStep, nextLabel } =
+view attrs { steps, currentStep, translate } =
     let
         centerLabel =
             Text.textLight
                 |> Text.view [] [ Html.text (String.fromInt currentStep ++ "/" ++ String.fromInt (List.length steps)) ]
     in
-    Html.div (css [ displayFlex, alignItems center ] :: attrs)
+    Html.div
+        (css [ displayFlex, alignItems center ]
+            :: attrs
+        )
         [ ProgressBar.init
             { progress = (toFloat currentStep / toFloat (List.length steps)) * 100
             , isCompleted = False
@@ -59,8 +62,18 @@ view attrs { steps, currentStep, nextLabel } =
                     , width (rem 3.5) |> Css.important
                     , height (rem 3.5) |> Css.important
                     ]
+                , attribute "aria-label"
+                    (translate strings.step
+                        ++ " "
+                        ++ String.fromInt currentStep
+                        ++ " "
+                        ++ translate strings.of_
+                        ++ " "
+                        ++ String.fromInt (List.length steps)
+                    )
                 ]
-        , Html.div [ css [ displayFlex, flexDirection column ] ]
+        , Html.div
+            [ css [ displayFlex, flexDirection column ] ]
             [ steps
                 |> List.getAt (currentStep - 1)
                 |> viewMaybe (\step -> Text.textLight |> Text.view [] [ Html.text step ])
@@ -71,18 +84,29 @@ view attrs { steps, currentStep, nextLabel } =
                         Text.textTiny
                             |> Text.view
                                 [ css [ color Colors.darkGray ] ]
-                                [ Html.text (nextLabel strings.next ++ step) ]
+                                [ Html.text (translate strings.next ++ step) ]
                     )
             ]
         ]
 
 
-strings : { next : Translation }
 strings =
     { next =
         { no = "Neste: "
         , se = "Nästa: "
         , dk = "Næste: "
         , en = "Next: "
+        }
+    , step =
+        { no = "Steg"
+        , se = "Steg"
+        , dk = "Trin"
+        , en = "Step"
+        }
+    , of_ =
+        { no = "av"
+        , se = "av"
+        , dk = "af"
+        , en = "of"
         }
     }


### PR DESCRIPTION
Add accessibility label for progress bar stepper. It now read: "step 4 of 9" (same as displayed visually) instead of just "progress bar".