### PR TITLE
Make Toggle more accessible

### DIFF
--- a/explorer/src/Stories/Toggle.elm
+++ b/explorer/src/Stories/Toggle.elm
@@ -1,37 +1,64 @@
 module Stories.Toggle exposing (stories)
 
 import Config exposing (Config, Msg(..))
-import Html.Styled exposing (div)
-import Html.Styled.Attributes exposing (disabled)
+import Css exposing (column, cursor, displayFlex, flexDirection, pointer, rem)
+import Html.Styled as Html exposing (div)
+import Html.Styled.Attributes as Attributes exposing (css, disabled)
+import Nordea.Components.Text as Text
 import Nordea.Components.Toggle as Toggle
+import Nordea.Css exposing (rowGap)
+import Nordea.Html as Html
 import UIExplorer exposing (UI)
 import UIExplorer.Styled exposing (styledStoriesOf)
 
 
 stories : UI Config Msg {}
 stories =
+    let
+        toggle checked attrs extra =
+            Toggle.init "Hey" (\_ -> ToggleToggle)
+                |> Toggle.withIsChecked checked
+                |> Toggle.view attrs extra
+    in
     styledStoriesOf
         "Toggle"
         [ ( "Toggle"
           , \model ->
-                div []
-                    [ Toggle.view []
-                        { name = "Hey"
-                        , onCheck = \_ -> ToggleToggle
-                        , isChecked = model.customModel.isToggled
-                        }
+                let
+                    checked =
+                        model.customModel.isToggled
+
+                    customId =
+                        "custom-toggle-input"
+                in
+                div [ css [ displayFlex, flexDirection column, rowGap (rem 1) ] ]
+                    [ Toggle.init "Hey" (\_ -> ToggleToggle)
+                        |> Toggle.withIsChecked checked
+                        |> Toggle.withInputAttrs [ Attributes.attribute "aria-label" "Input must have some labelling" ]
+                        |> Toggle.view [] []
+                    , toggle checked [] [ "With toggle label" |> Html.text ]
+                    , Toggle.init "Hey" (\_ -> ToggleToggle)
+                        |> Toggle.withIsChecked checked
+                        |> Toggle.withHtmlTag Html.row
+                        |> Toggle.withInputAttrs [ Attributes.id customId ]
+                        |> Toggle.view [ css [ displayFlex, flexDirection column ] ]
+                            [ Html.column [ css [ rowGap (rem 1) ] ]
+                                [ Text.textHeavy
+                                    |> Text.withHtmlTag Html.label
+                                    |> Text.view [ Attributes.for customId, css [ cursor pointer ] ]
+                                        [ "Separate label with embedded toggle:" |> Html.text ]
+                                , Text.textTiny |> Text.view [] [ "(HTML doesn't allow nesting labels)" |> Html.text ]
+                                , Toggle.init "embedded" (\_ -> ToggleToggle)
+                                    |> Toggle.withIsChecked checked
+                                    |> Toggle.view [] [ "I'm on a separate label" |> Html.text ]
+                                ]
+                            ]
                     ]
           , {}
           )
         , ( "Toggle (Disabled)"
           , \model ->
-                div []
-                    [ Toggle.view [ disabled True ]
-                        { name = "Hey"
-                        , onCheck = \_ -> ToggleToggle
-                        , isChecked = model.customModel.isToggled
-                        }
-                    ]
+                div [] [ toggle model.customModel.isToggled [ disabled True ] [ "Disabled" |> Html.text ] ]
           , {}
           )
         ]

--- a/src/Nordea/Components/Toggle.elm
+++ b/src/Nordea/Components/Toggle.elm
@@ -1,4 +1,4 @@
-module Nordea.Components.Toggle exposing (view)
+module Nordea.Components.Toggle exposing (Toggle, init, view, withHtmlTag, withInputAttrs, withIsChecked)
 
 import Css
     exposing
@@ -16,6 +16,7 @@ import Css
         , height
         , hex
         , left
+        , marginRight
         , opacity
         , pct
         , pointer
@@ -35,41 +36,58 @@ import Css.Transitions as Transitions
 import Html.Styled as Html exposing (Attribute, Html)
 import Html.Styled.Attributes as Attrs exposing (class, css, name, type_)
 import Html.Styled.Events as Events
+import Maybe.Extra as Maybe
+import Nordea.Html as Html
 import Nordea.Resources.Colors as Colors
 import Nordea.Themes as Themes
+
+
+type Toggle msg
+    = Toggle (ToggleProperties msg)
+
+
+type alias HtmlTag msg =
+    List (Attribute msg) -> List (Html msg) -> Html msg
 
 
 type alias ToggleProperties msg =
     { name : String
     , onCheck : Bool -> msg
     , isChecked : Bool
+    , customHtmlTag : Maybe (HtmlTag msg)
+    , inputAttrs : List (Attribute msg)
     }
 
 
-view : List (Attribute msg) -> ToggleProperties msg -> Html msg
-view attrs toggleProperties =
+init : String -> (Bool -> msg) -> Toggle msg
+init name onCheck =
+    { name = name
+    , onCheck = onCheck
+    , isChecked = False
+    , customHtmlTag = Nothing
+    , inputAttrs = []
+    }
+        |> Toggle
+
+
+view : List (Attribute msg) -> List (Html msg) -> Toggle msg -> Html msg
+view attrs content (Toggle config) =
     let
         isDisabled =
             List.member (Attrs.disabled True) attrs
+
+        onCheckValue =
+            not config.isChecked
     in
-    Html.label
-        (css
-            [ displayFlex
-            , alignItems center
-            , position relative
-            , height (rem 1.5)
-            , width (rem 2.625)
-            , cursor pointer
-            ]
-            :: attrs
-        )
-        [ Html.input
-            [ type_ "checkBox"
-            , name toggleProperties.name
-            , Attrs.checked toggleProperties.isChecked
-            , Events.onCheck toggleProperties.onCheck
-            , Attrs.disabled isDisabled
-            , css
+    (config.customHtmlTag |> Maybe.withDefault labelTag)
+        (css [ position relative ] :: attrs)
+        ([ Html.input
+            ([ type_ "checkBox"
+             , name config.name
+             , Attrs.checked config.isChecked
+             , Attrs.disabled isDisabled
+             , Events.onCheck config.onCheck
+             , css
                 [ opacity zero
                 , height zero
                 , width zero
@@ -84,17 +102,24 @@ view attrs toggleProperties =
                     , after [ backgroundColor Colors.mediumGray ]
                     ]
                 ]
-            ]
+             ]
+                ++ config.inputAttrs
+            )
             []
-        , Html.span
+         , Html.span
             [ class "nfe-toggle"
+
+            -- If the container isn't a label, we need to catch the click here or it gets lost.
+            , Events.onClick (config.onCheck onCheckValue) |> Html.attrIf (Maybe.isJust config.customHtmlTag)
+            , Attrs.attribute "aria-hidden" "true"
             , css
-                [ width (pct 100)
-                , height (pct 100)
+                [ height (rem 1.5)
+                , width (rem 2.625)
                 , backgroundColor Colors.mediumGray
                 , border3 (rem 0.125) solid Colors.mediumGray
                 , borderRadius (rem 1)
                 , position relative
+                , marginRight (rem 0.5)
                 , after
                     [ display block
                     , property "content" "''"
@@ -112,4 +137,33 @@ view attrs toggleProperties =
                 ]
             ]
             []
-        ]
+         ]
+            ++ content
+        )
+
+
+withIsChecked : Bool -> Toggle msg -> Toggle msg
+withIsChecked isChecked (Toggle config) =
+    Toggle { config | isChecked = isChecked }
+
+
+withHtmlTag : HtmlTag msg -> Toggle msg -> Toggle msg
+withHtmlTag container (Toggle config) =
+    Toggle { config | customHtmlTag = Just container }
+
+
+withInputAttrs : List (Attribute msg) -> Toggle msg -> Toggle msg
+withInputAttrs inputAttrs (Toggle config) =
+    Toggle { config | inputAttrs = inputAttrs }
+
+
+labelTag : List (Attribute msg) -> List (Html msg) -> Html msg
+labelTag attrs =
+    Html.label
+        (css
+            [ displayFlex
+            , alignItems center
+            , cursor pointer
+            ]
+            :: attrs
+        )


### PR DESCRIPTION
- Rework to the config .with* pattern.
- Allow special quirks for difficult UI patterns.

# Story:
<img width="483" height="337" alt="image" src="https://github.com/user-attachments/assets/f25f7cca-ec8b-4a12-beb0-4c1993d0827a" />

# Firefox a11y view
<img width="612" height="373" alt="image" src="https://github.com/user-attachments/assets/13ad6751-8de2-4281-aa4e-979939b4f466" />
