### PR TITLE
Add withHtmlTag to Card

### DIFF
--- a/explorer/src/Stories/Card.elm
+++ b/explorer/src/Stories/Card.elm
@@ -1,7 +1,7 @@
 module Stories.Card exposing (stories)
 
 import Config exposing (Config, Msg(..))
-import Css exposing (alignItems, center, displayFlex, rem, width)
+import Css exposing (alignItems, center, displayFlex, marginTop, padding, rem, width)
 import Html.Styled as Html
 import Html.Styled.Attributes exposing (css)
 import Nordea.Components.Card as Card
@@ -85,6 +85,21 @@ stories =
                                 ]
                             ]
                         ]
+          , {}
+          )
+        , ( "With custom HTML tag"
+          , \_ ->
+                Html.ul [ css [ padding (rem 0) ] ]
+                    ([ "One", "Two", "Three" ]
+                        |> List.map (Html.text >> List.singleton)
+                        |> List.map
+                            (\content ->
+                                Card.init
+                                    |> Card.withShadow
+                                    |> Card.withHtmlTag Html.li
+                                    |> Card.view [ css [ marginTop (rem 1) ] ] content
+                            )
+                    )
           , {}
           )
         ]

--- a/src/Nordea/Components/Card.elm
+++ b/src/Nordea/Components/Card.elm
@@ -6,6 +6,7 @@ module Nordea.Components.Card exposing
     , isCollapsible
     , title
     , view
+    , withHtmlTag
     , withHtmlTitle
     , withShadow
     , withTitle
@@ -61,6 +62,7 @@ type alias CardProperties msg =
     , isCollapsible : Bool
     , isOpen : Bool
     , onClick : Maybe msg
+    , htmlTag : Maybe (List (Attribute msg) -> List (Html msg) -> Html msg)
     }
 
 
@@ -77,6 +79,7 @@ init =
         , isCollapsible = False
         , isOpen = False
         , onClick = Nothing
+        , htmlTag = Nothing
         }
 
 
@@ -95,6 +98,10 @@ view attrs children (Card config) =
                     |> styleIf config.hasShadow
                 ]
                 :: attrs
+
+        baseTag =
+            config.htmlTag
+                |> Maybe.withDefault Html.div
     in
     if config.isCollapsible then
         AccordionMenu.view { isOpen = config.isOpen }
@@ -106,13 +113,13 @@ view attrs children (Card config) =
                     |> viewMaybe
                         (\emphasisedText_ -> emphasisedTextWithTransition emphasisedText_)
                 ]
-            , Html.div [ css [ marginTop (rem 1.5) ] ] children
+            , baseTag [ css [ marginTop (rem 1.5) ] ] children
             ]
 
     else
         case config.title of
             Just title_ ->
-                Html.div
+                baseTag
                     (css
                         [ Css.children [ Css.everything [ firstChild [ marginBottom (rem 1.5) ] ] ] ]
                         :: baseStyle
@@ -120,7 +127,7 @@ view attrs children (Card config) =
                     (title_ :: children)
 
             Nothing ->
-                Html.div baseStyle children
+                baseTag baseStyle children
 
 
 headerCollapsible : List (Attribute msg) -> List (Html msg) -> Html msg
@@ -205,6 +212,11 @@ withHtmlTitle title_ (Card config) =
 withShadow : Card msg -> Card msg
 withShadow (Card config) =
     Card { config | hasShadow = True }
+
+
+withHtmlTag : (List (Attribute msg) -> List (Html msg) -> Html msg) -> Card msg -> Card msg
+withHtmlTag htmlTag (Card config) =
+    Card { config | htmlTag = Just htmlTag }
 
 
 isCollapsible :


### PR DESCRIPTION
Allows using e.g. `li` to make shallower hierarchies.
<img width="957" height="342" alt="image" src="https://github.com/user-attachments/assets/00aca05d-debf-4676-a49f-9dff9a13ab81" />
